### PR TITLE
feat: align creation page nav/layout with kesson-style structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>創造とは - Creation Space</title>
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;400&display=swap" rel="stylesheet">
@@ -30,12 +31,59 @@
 <body class="creation-page">
   <div id="canvas-container" aria-hidden="true"></div>
 
-  <div id="credit">
-    <div class="credit-line" id="credit-collab">Quantum field sketch</div>
-    <div class="credit-signature" id="credit-signature">creation-space</div>
-  </div>
+  <header id="kesson-topbar" class="navbar navbar-expand-md navbar-dark" aria-label="Main menu">
+    <div class="container-fluid px-3 px-md-4">
+      <div class="topbar-brand-wrap">
+        <a id="topbar-main-title" class="navbar-brand topbar-main-title" href="#">
+          創造とは
+        </a>
+        <span id="topbar-subtitle" class="topbar-subtitle">Creation Space</span>
+        <span class="topbar-meta topbar-meta--author" id="credit-signature">Project Concept: What Is Creation</span>
+      </div>
+      <button
+        class="navbar-toggler topbar-toggler"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#kessonTopbarNav"
+        aria-controls="kessonTopbarNav"
+        aria-expanded="false"
+        aria-label="Toggle menu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse justify-content-end" id="kessonTopbarNav">
+        <ul class="navbar-nav align-items-md-center gap-md-1">
+          <li class="nav-item">
+            <a id="topbar-home-link" class="nav-link topbar-link" href="#">HOME</a>
+          </li>
+          <li class="nav-item">
+            <button
+              id="topbar-articles-btn"
+              type="button"
+              class="nav-link topbar-link topbar-link-btn"
+              data-bs-toggle="offcanvas"
+              data-bs-target="#articlesOffcanvas"
+              aria-controls="articlesOffcanvas">
+              ARTICLES
+            </button>
+          </li>
+          <li class="nav-item topbar-lang-item">
+            <button
+              type="button"
+              id="lang-toggle"
+              class="nav-link topbar-link topbar-link-btn topbar-lang-btn"
+              aria-label="言語を英語に切り替え">
+              English
+            </button>
+          </li>
+          <li class="nav-item topbar-collab-item">
+            <span id="credit-collab" class="topbar-collab-note">AIとの協働で探索中</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </header>
 
-  <div id="overlay">
+  <div id="overlay" role="presentation">
     <div id="taglines"></div>
     <h1 id="title-h1">創造とは</h1>
     <p class="subtitle" id="title-sub">Creation Field</p>
@@ -52,11 +100,6 @@
       <span class="guide-sep">—</span>
       <span class="guide-action" data-ja="ズーム" data-en="zoom">zoom</span>
     </div>
-    <div class="guide-row guide-desktop">
-      <span class="guide-key" data-ja="スクロール" data-en="scroll">scroll</span>
-      <span class="guide-sep">—</span>
-      <span class="guide-action" data-ja="潜水" data-en="dive">dive</span>
-    </div>
     <div class="guide-row guide-touch">
       <span class="guide-key" data-ja="横スワイプ" data-en="swipe">swipe</span>
       <span class="guide-sep">—</span>
@@ -66,11 +109,6 @@
       <span class="guide-key" data-ja="ピンチ" data-en="pinch">pinch</span>
       <span class="guide-sep">—</span>
       <span class="guide-action" data-ja="ズーム" data-en="zoom">zoom</span>
-    </div>
-    <div class="guide-row guide-touch">
-      <span class="guide-key" data-ja="縦スクロール" data-en="scroll">scroll</span>
-      <span class="guide-sep">—</span>
-      <span class="guide-action" data-ja="潜水" data-en="dive">dive</span>
     </div>
   </div>
 
@@ -86,7 +124,76 @@
 
   <div id="hero-spacer"></div>
   <div id="articles-spacer"></div>
+
+  <section id="articles-section">
+    <div class="section-content-wrap">
+      <div class="container">
+        <h2 class="section-heading">
+          <a id="articles-section-heading" href="#articles-section" class="section-heading-link" aria-label="ARTICLES セクションへジャンプ">
+            ARTICLES
+          </a>
+        </h2>
+        <div id="articles-error" class="d-none"></div>
+        <div id="articles-grid" class="row g-3"></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="creation-cards-section">
+    <div class="section-content-wrap">
+      <div class="container">
+        <h2 class="section-heading">
+          <span id="creation-cards-heading">CREATION CARDS</span>
+        </h2>
+        <div id="creation-cards-container" class="row g-3">
+          <article class="col-12 col-md-6 col-xl-4">
+            <div class="creation-card-placeholder">
+              <h3 id="creation-card-slot-1-title">Card Slot 01</h3>
+              <p id="creation-card-slot-1-body">content to be specified</p>
+            </div>
+          </article>
+          <article class="col-12 col-md-6 col-xl-4">
+            <div class="creation-card-placeholder">
+              <h3 id="creation-card-slot-2-title">Card Slot 02</h3>
+              <p id="creation-card-slot-2-body">content to be specified</p>
+            </div>
+          </article>
+          <article class="col-12 col-md-6 col-xl-4">
+            <div class="creation-card-placeholder">
+              <h3 id="creation-card-slot-3-title">Card Slot 03</h3>
+              <p id="creation-card-slot-3-body">content to be specified</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <div id="creation-spacer"></div>
+
+  <footer id="tech-footer">
+    <div class="tech-footer-line">GitHub Pages</div>
+    <div class="tech-footer-line">Vanilla JS · ES Modules</div>
+    <div class="tech-footer-line">Three.js · Bootstrap</div>
+  </footer>
+
+  <div class="offcanvas offcanvas-end offcanvas-kesson" tabindex="-1" id="articlesOffcanvas" data-bs-backdrop="true">
+    <div class="offcanvas-header border-bottom border-secondary">
+      <div>
+        <h5 id="offcanvas-articles-title" class="text-light mb-0 offcanvas-title-spaced">ARTICLES</h5>
+        <small class="text-muted" id="offcanvas-articles-count"></small>
+      </div>
+      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body p-3">
+      <div id="articles-filter-group" class="articles-filter-group mb-3" role="group" aria-label="Filter articles by type">
+        <button type="button" class="articles-filter-btn is-active" data-type="all" aria-pressed="true">All</button>
+        <button type="button" class="articles-filter-btn" data-type="page" aria-pressed="false">Page</button>
+        <button type="button" class="articles-filter-btn" data-type="post" aria-pressed="false">Post</button>
+      </div>
+      <div id="offcanvas-articles-grid" class="row g-3"></div>
+    </div>
+  </div>
 
   <button id="surface-btn" aria-label="ページ上部に戻る">↑ surface</button>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -32,17 +32,43 @@ const STRINGS = {
         title: '創造とは',
         subtitle: 'Creation Field',
         taglines: [
-            '量子の場のように、透明な揺らぎが重なって立ち上がる。',
-            '観測の手前にある波の層を、ゆっくり潜って見る。',
+            '関係し合う欠片が、まだ名前を持たない輪郭を生む。',
+            '観測と選択のあいだで、創造は静かに立ち上がる。',
         ],
+        topbarMainTitle: '創造とは',
+        topbarSubtitle: 'Creation Space',
+        topbarHome: 'HOME',
+        topbarArticles: 'ARTICLES',
+        topbarCollab: 'AIとの協働で探索中',
+        creditSignature: 'Project Concept: What Is Creation',
+        articlesSectionHeading: 'ARTICLES',
+        offcanvasArticlesTitle: 'ARTICLES',
+        creationCardsHeading: 'CREATION CARDS',
+        creationCardTitlePrefix: 'Card Slot',
+        creationCardBody: '内容は後続指定',
+        langToggleLabel: 'English',
+        langToggleAria: '言語を英語に切り替え',
     },
     en: {
         title: 'What Is Creation',
         subtitle: 'Creation Field',
         taglines: [
-            'Transparent waves overlap like a quantum field.',
-            'Dive into layered fluctuations before they collapse into form.',
+            'Fragments in relation generate forms before they are named.',
+            'Creation rises quietly between observation and choice.',
         ],
+        topbarMainTitle: 'What Is Creation',
+        topbarSubtitle: 'Creation Space',
+        topbarHome: 'HOME',
+        topbarArticles: 'ARTICLES',
+        topbarCollab: 'Exploring with AI collaboration',
+        creditSignature: 'Project Concept: What Is Creation',
+        articlesSectionHeading: 'ARTICLES',
+        offcanvasArticlesTitle: 'ARTICLES',
+        creationCardsHeading: 'CREATION CARDS',
+        creationCardTitlePrefix: 'Card Slot',
+        creationCardBody: 'content to be specified',
+        langToggleLabel: '日本語',
+        langToggleAria: 'Switch language to Japanese',
     },
 };
 
@@ -70,9 +96,39 @@ function applyPageLanguage(lang) {
     const titleH1 = document.getElementById('title-h1');
     const titleSub = document.getElementById('title-sub');
     const taglineContainer = document.getElementById('taglines');
+    const topbarMainTitle = document.getElementById('topbar-main-title');
+    const topbarSubtitle = document.getElementById('topbar-subtitle');
+    const topbarHomeLink = document.getElementById('topbar-home-link');
+    const topbarArticlesBtn = document.getElementById('topbar-articles-btn');
+    const topbarCollab = document.getElementById('credit-collab');
+    const creditSignature = document.getElementById('credit-signature');
+    const articlesSectionHeading = document.getElementById('articles-section-heading');
+    const offcanvasArticlesTitle = document.getElementById('offcanvas-articles-title');
+    const creationCardsHeading = document.getElementById('creation-cards-heading');
+    const langToggle = document.getElementById('lang-toggle');
 
     if (titleH1) titleH1.textContent = strings.title;
     if (titleSub) titleSub.textContent = strings.subtitle;
+    if (topbarMainTitle) topbarMainTitle.textContent = strings.topbarMainTitle;
+    if (topbarSubtitle) topbarSubtitle.textContent = strings.topbarSubtitle;
+    if (topbarHomeLink) topbarHomeLink.textContent = strings.topbarHome;
+    if (topbarArticlesBtn) topbarArticlesBtn.textContent = strings.topbarArticles;
+    if (topbarCollab) topbarCollab.textContent = strings.topbarCollab;
+    if (creditSignature) creditSignature.textContent = strings.creditSignature;
+    if (articlesSectionHeading) articlesSectionHeading.textContent = strings.articlesSectionHeading;
+    if (offcanvasArticlesTitle) offcanvasArticlesTitle.textContent = strings.offcanvasArticlesTitle;
+    if (creationCardsHeading) creationCardsHeading.textContent = strings.creationCardsHeading;
+    if (langToggle) {
+        langToggle.textContent = strings.langToggleLabel;
+        langToggle.setAttribute('aria-label', strings.langToggleAria);
+    }
+
+    [1, 2, 3].forEach((slotIndex) => {
+        const titleNode = document.getElementById(`creation-card-slot-${slotIndex}-title`);
+        const bodyNode = document.getElementById(`creation-card-slot-${slotIndex}-body`);
+        if (titleNode) titleNode.textContent = `${strings.creationCardTitlePrefix} ${String(slotIndex).padStart(2, '0')}`;
+        if (bodyNode) bodyNode.textContent = strings.creationCardBody;
+    });
 
     if (taglineContainer) {
         taglineContainer.innerHTML = '';

--- a/src/scroll-ui.js
+++ b/src/scroll-ui.js
@@ -14,8 +14,6 @@ let _langToggle;
 let _scrollHintBottom;
 let _scrollHintTop;
 let _surfaceBtn;
-let _devlogHeader;
-let _devlogSection;
 let _articlesSection;
 
 // --- T-014: クリーンアップ ---
@@ -34,13 +32,7 @@ export function initScrollUI() {
     _scrollHintBottom = document.getElementById('scroll-hint');
     _scrollHintTop = document.getElementById('scroll-hint-top');
     _surfaceBtn = document.getElementById('surface-btn');
-    _devlogHeader = document.getElementById('devlog-gallery-header');
-    _devlogSection = document.getElementById('devlog-gallery-section');
     _articlesSection = document.getElementById('articles-section');
-
-    if (_devlogHeader) {
-        _devlogHeader.classList.remove('is-visible');
-    }
 
     // 浮上ボタン: クリックでページ最上部へ
     if (_surfaceBtn) {
@@ -161,8 +153,6 @@ export function updateScrollUI(scrollProg, breathVal) {
         _surfaceBtn.style.pointerEvents = showSurface ? 'auto' : 'none';
     }
 
-    // --- Devlogタイトル: セクション内でのみ表示 ---
-    updateDevlogHeaderVisibility(scrollProg);
     updateArticlesFocusability(scrollProg);
 }
 
@@ -198,21 +188,6 @@ function updateArticlesFocusability(scrollProg) {
         }
         el.setAttribute('tabindex', '-1');
     });
-}
-
-function updateDevlogHeaderVisibility(scrollProg) {
-    if (!_devlogHeader) return;
-    const rect = _devlogSection ? _devlogSection.getBoundingClientRect() : null;
-    const windowH = window.innerHeight || document.documentElement.clientHeight;
-    const exitLine = windowH * 0.05;
-    const TRACES_ENTER_Y = 0; // px: TRACES出現の基準ライン（調整用）
-    const spacer = document.getElementById('articles-spacer');
-    const spacerPassed = spacer
-        ? spacer.getBoundingClientRect().top <= TRACES_ENTER_Y
-        : scrollProg > 0.3;
-    const stillInRange = rect ? rect.bottom >= exitLine : true;
-    const isVisible = spacerPassed && stillInRange;
-    _devlogHeader.classList.toggle('is-visible', isVisible);
 }
 
 /**

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -28,6 +28,13 @@
       --kesson-card-bg: rgba(20, 25, 40, 0.9);
       --kesson-offcanvas-width: 85%;
       --kesson-offcanvas-bg: rgba(10, 14, 26, 0.98);
+      --kesson-topbar-height: 3.25rem;
+      --kesson-topbar-alpha-strong: 0.10;
+      --kesson-topbar-alpha-soft: 0.10;
+      --kesson-topbar-border-alpha: 0.22;
+      --kesson-topbar-shadow-alpha: 0.26;
+      --kesson-topbar-blur: 14px;
+      --kesson-topbar-saturate: 145%;
     }
     
     #canvas-container {
@@ -37,6 +44,193 @@
       width: 100%;
       height: 100%;
       z-index: 1;
+    }
+
+    /* ============================
+       Top menu bar (Bootstrap navbar)
+       ============================ */
+    #kesson-topbar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      min-height: var(--kesson-topbar-height);
+      z-index: 60;
+      background: linear-gradient(
+        to bottom,
+        rgba(10, 14, 24, var(--kesson-topbar-alpha-strong)) 0%,
+        rgba(10, 14, 24, var(--kesson-topbar-alpha-soft)) 100%
+      );
+      border-bottom: 1px solid rgba(130, 170, 240, var(--kesson-topbar-border-alpha));
+      box-shadow: 0 10px 24px rgba(0, 0, 0, var(--kesson-topbar-shadow-alpha));
+      backdrop-filter: blur(var(--kesson-topbar-blur)) saturate(var(--kesson-topbar-saturate));
+      -webkit-backdrop-filter: blur(var(--kesson-topbar-blur)) saturate(var(--kesson-topbar-saturate));
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    #kesson-topbar .container-fluid {
+      min-height: var(--kesson-topbar-height);
+    }
+    #kesson-topbar .topbar-brand-wrap {
+      display: flex;
+      align-items: baseline;
+      gap: 0.52rem;
+      min-width: 0;
+      max-width: calc(100% - 3rem);
+      white-space: nowrap;
+      overflow: hidden;
+      padding: 0.24rem 0;
+    }
+    #kesson-topbar .topbar-main-title {
+      color: rgba(228, 238, 255, 0.92);
+      font-family: "Noto Serif JP", "Yu Mincho", "MS PMincho", serif;
+      font-size: clamp(0.96rem, 1.85vw, 1.38rem);
+      letter-spacing: 0.04em;
+      line-height: 1;
+      text-transform: none;
+      margin: 0;
+      padding: 0;
+      text-decoration: none;
+      flex: 0 0 auto;
+    }
+    #kesson-topbar .topbar-main-title:hover,
+    #kesson-topbar .topbar-main-title:focus-visible {
+      color: rgba(242, 248, 255, 1);
+    }
+    #kesson-topbar .topbar-subtitle {
+      font-size: clamp(0.72rem, 1.05vw, 0.86rem);
+      color: rgba(205, 220, 244, 0.76);
+      letter-spacing: 0.1em;
+      line-height: 1;
+      text-transform: none;
+      flex: 0 0 auto;
+      pointer-events: none;
+    }
+    #kesson-topbar .topbar-subtitle::before,
+    #kesson-topbar .topbar-meta::before {
+      content: '·';
+      color: rgba(170, 192, 228, 0.42);
+      margin-right: 0.45rem;
+    }
+    #kesson-topbar .topbar-meta {
+      display: block;
+      flex: 0 0 auto;
+      padding: 0;
+      font-size: clamp(0.62rem, 0.88vw, 0.7rem);
+      line-height: 1;
+      letter-spacing: 0.05em;
+      color: rgba(186, 204, 234, 0.72);
+      font-family: 'Georgia', "Noto Serif JP", serif;
+      pointer-events: none;
+    }
+    #kesson-topbar .topbar-meta--author {
+      font-size: 0.68rem;
+      color: rgba(184, 203, 234, 0.74);
+    }
+    #kesson-topbar .topbar-link {
+      color: rgba(205, 220, 244, 0.78);
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 0.68rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 0.4rem 0.72rem;
+      border-radius: 999px;
+      transition: color 0.25s ease, background-color 0.25s ease;
+    }
+    #kesson-topbar .topbar-link:hover,
+    #kesson-topbar .topbar-link:focus-visible {
+      color: rgba(236, 244, 255, 0.98);
+      background: rgba(120, 165, 240, 0.2);
+    }
+    #kesson-topbar .topbar-link-btn {
+      border: 0;
+      background: transparent;
+      line-height: inherit;
+      width: 100%;
+      text-align: left;
+    }
+    #kesson-topbar .topbar-lang-btn {
+      color: rgba(218, 232, 255, 0.9);
+      border: 1px solid rgba(130, 170, 240, 0.25);
+      background: rgba(70, 102, 160, 0.16);
+    }
+    #kesson-topbar .topbar-collab-item {
+      margin-left: 0.45rem;
+      padding-left: 0.55rem;
+      border-left: 1px solid rgba(130, 170, 240, 0.2);
+    }
+    #kesson-topbar .topbar-collab-note {
+      display: inline-block;
+      font-family: 'Georgia', "Noto Serif JP", serif;
+      font-size: clamp(0.58rem, 0.82vw, 0.66rem);
+      line-height: 1;
+      letter-spacing: 0.06em;
+      color: rgba(165, 214, 255, 0.74);
+      white-space: nowrap;
+      pointer-events: none;
+      user-select: none;
+    }
+    #kesson-topbar .topbar-toggler {
+      border-color: rgba(145, 178, 242, 0.55);
+      padding: 0.18rem 0.44rem;
+    }
+    #kesson-topbar .topbar-toggler:focus {
+      box-shadow: 0 0 0 0.14rem rgba(140, 180, 252, 0.35);
+    }
+    #kessonTopbarNav {
+      margin-top: 0.35rem;
+      padding: 0.35rem 0.2rem 0.5rem;
+      border-radius: 0.6rem;
+      background: rgba(9, 13, 24, 0.82);
+      border: 1px solid rgba(130, 170, 240, 0.2);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+    @media (min-width: 768px) {
+      #kessonTopbarNav {
+        margin-top: 0;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+      }
+      #kesson-topbar .topbar-link-btn {
+        width: auto;
+        text-align: center;
+      }
+      #kesson-topbar .topbar-lang-item {
+        margin-left: 0.35rem;
+      }
+    }
+    @media (max-width: 991.98px) {
+      #kesson-topbar .topbar-meta--author {
+        display: none;
+      }
+      #kesson-topbar .topbar-subtitle {
+        font-size: 0.66rem;
+      }
+      #kesson-topbar .topbar-collab-item {
+        margin-left: 0.3rem;
+        padding-left: 0.45rem;
+      }
+    }
+    @media (max-width: 767.98px) {
+      #kesson-topbar .topbar-subtitle {
+        display: none;
+      }
+      #kesson-topbar .topbar-main-title {
+        font-size: 0.86rem;
+      }
+      #kesson-topbar .topbar-collab-item {
+        margin-left: 0;
+        padding: 0.28rem 0.76rem 0 0.76rem;
+        border-left: 0;
+      }
+      #kesson-topbar .topbar-collab-note {
+        font-size: 0.62rem;
+        letter-spacing: 0.05em;
+      }
     }
 
     /* ============================
@@ -286,7 +480,7 @@
     /* --- 上部 scroll hint --- */
     #scroll-hint-top {
       position: fixed;
-      top: 16px;
+      top: calc(var(--kesson-topbar-height) + 6px);
       left: 50%;
       transform: translateX(-50%);
       z-index: 20;
@@ -329,7 +523,7 @@
        ============================ */
     #control-guide {
       position: fixed;
-      top: 8%;
+      top: calc(var(--kesson-topbar-height) + 2.1rem);
       right: 3%;
       z-index: 10;
       pointer-events: none;
@@ -369,47 +563,8 @@
       #control-guide .guide-desktop { display: none; }
     }
 
-    /* ============================
-       Devlog Gallery (3D cards) — 透明背景
-       ============================ */
-    #devlog-gallery-section {
-      position: relative;
-      z-index: 5;
-      width: 100%;
-      background: transparent;
-      padding-bottom: 2rem;
-    }
-    #devlog-gallery-container {
-      position: relative;
-      width: 100%;
-    }
-    /* devlog gallery container — ナビバーとの間隔 */
-    #devlog-gallery-container > .container {
-      margin-top: var(--kesson-section-grid-margin-top);
-    }
     #articles-grid {
       margin-top: var(--kesson-section-grid-margin-top);
-    }
-    #devlog-gallery-header {
-      position: fixed;
-      top: 20px;
-      left: 24px;
-      z-index: 20;
-      pointer-events: none;
-      opacity: 0;
-      transition: opacity 0.4s ease;
-    }
-    #devlog-gallery-header.is-visible {
-      opacity: 1;
-    }
-    #devlog-gallery-header h2 {
-      font-size: 0.75rem;
-      font-weight: 400;
-      color: rgba(var(--color-sub-text), 0.5);
-      letter-spacing: 0.15em;
-      text-transform: uppercase;
-      margin: 0;
-      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
     }
 
     /* Read Moreボタン */
@@ -535,52 +690,6 @@
       outline-offset: 4px;
     }
 
-    /* ============================
-       Offcanvas 詳細ビュー
-       ============================ */
-    .session-content {
-      color: #94a3b8;
-      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-    }
-    .session-content h1,
-    .session-content h2,
-    .session-content h3 {
-      color: #e2e8f0;
-      margin-top: 1.5em;
-      margin-bottom: 0.5em;
-    }
-    .session-content h1 { font-size: 1.3rem; }
-    .session-content h2 { font-size: 1.1rem; }
-    .session-content h3 { font-size: 0.95rem; }
-    .session-content p {
-      font-size: 0.85rem;
-      line-height: 1.8;
-      color: #94a3b8;
-      margin-bottom: 1em;
-      font-family: "Noto Serif JP", "Yu Mincho", serif;
-    }
-    .session-content ul,
-    .session-content ol {
-      font-size: 0.85rem;
-      line-height: 1.8;
-      color: #94a3b8;
-      padding-left: 1.5em;
-    }
-    .session-content code {
-      background: rgba(var(--color-accent), 0.1);
-      padding: 0.15em 0.4em;
-      border-radius: 3px;
-      font-size: 0.8em;
-    }
-    .session-content pre {
-      background: rgba(0, 0, 0, 0.3);
-      padding: 1em;
-      border-radius: 4px;
-      overflow-x: auto;
-    }
-    .session-content a {
-      color: #f59e0b;
-    }
     .offcanvas-body::-webkit-scrollbar { width: 6px; }
     .offcanvas-body::-webkit-scrollbar-track { background: transparent; }
     .offcanvas-body::-webkit-scrollbar-thumb { background: #1e293b; border-radius: 3px; }
@@ -596,14 +705,55 @@
       z-index: 5;
     }
 
-    /* Section content wrapper (shared by articles + devlog heading areas) */
+    #creation-cards-section {
+      position: relative;
+      z-index: 5;
+      padding-bottom: 3.5rem;
+    }
+
+    #creation-cards-container {
+      margin-top: var(--kesson-section-grid-margin-top);
+    }
+
+    .creation-card-placeholder {
+      min-height: 156px;
+      border: 1px dashed rgba(138, 176, 236, 0.44);
+      border-radius: 0.35rem;
+      background: rgba(17, 24, 40, 0.6);
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+    }
+
+    .creation-card-placeholder h3 {
+      margin: 0;
+      font-size: 0.76rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgba(224, 236, 255, 0.86);
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    }
+
+    .creation-card-placeholder p {
+      margin: 0.75rem 0 0;
+      color: rgba(var(--color-sub-text), 0.75);
+      font-size: 0.72rem;
+      line-height: 1.65;
+      letter-spacing: 0.04em;
+      font-family: "Noto Serif JP", "Yu Mincho", serif;
+    }
+
+    /* Section content wrapper (shared by content sections) */
     .section-content-wrap {
       position: relative;
       z-index: 20;
       padding: var(--kesson-section-content-padding);
     }
 
-    /* Section heading — monospace, all-caps (ARTICLES / DEVLOG) */
+    /* Section heading — monospace, all-caps */
     .section-heading {
       font-size: 0.75rem;
       font-weight: 400;


### PR DESCRIPTION
## Summary
- replace the page shell with a kesson-style topbar/nav and offcanvas article container
- align section structure for articles + placeholder creation cards
- update localized copy mappings for the new navigation/section labels
- remove devlog-specific scroll/header handling from runtime and styles

## Scope
This PR intentionally focuses on navigation/layout integration before Three.js object experiments.

## Related
- refs #3
- refs #4
- refs #5
- refs #6
- refs #10
- refs #11
