### PR TITLE
Navi follow-up: link updates, signature move, and graphic query rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,11 +36,9 @@
   <header id="kesson-topbar" class="navbar navbar-expand-md navbar-dark" aria-label="Main menu">
     <div class="container-fluid px-3 px-md-4">
       <div class="topbar-brand-wrap">
-        <a id="topbar-main-title" class="navbar-brand topbar-main-title" href="https://uminomae.github.io/pjdhiro/dialogueCreation/" target="_blank" rel="noopener">
+        <a id="topbar-main-title" class="navbar-brand topbar-main-title" href="./">
           創造とは
         </a>
-        <span id="topbar-subtitle" class="topbar-subtitle">Creation Space</span>
-        <span class="topbar-meta topbar-meta--author" id="credit-signature">Project Designer: pjdhiro</span>
       </div>
       <button
         class="navbar-toggler topbar-toggler"
@@ -55,7 +53,7 @@
       <div class="collapse navbar-collapse justify-content-end" id="kessonTopbarNav">
         <ul class="navbar-nav align-items-md-center gap-md-1">
           <li class="nav-item">
-            <a id="topbar-home-link" class="nav-link topbar-link" href="#">HOME</a>
+            <a id="topbar-home-link" class="nav-link topbar-link" href="../kesson-space/">kesson-driven</a>
           </li>
           <li class="nav-item">
             <a id="topbar-dev-link" class="nav-link topbar-link" href="./?dev">DEV</a>
@@ -100,10 +98,11 @@
   </header>
 
   <div id="graphic-switcher" class="btn-group btn-group-sm" role="group" aria-label="グラフィック切り替え">
-    <button type="button" class="btn btn-outline-light active" data-graphic-mode="hold" aria-pressed="true">保持</button>
-    <button type="button" class="btn btn-outline-light" data-graphic-mode="wabi" aria-pressed="false">忍</button>
-    <button type="button" class="btn btn-outline-light" data-graphic-mode="intent" aria-pressed="false">意</button>
+    <button type="button" class="btn btn-outline-light active" data-graphic-mode="hoji" aria-pressed="true">保持</button>
+    <button type="button" class="btn btn-outline-light" data-graphic-mode="sinobi" aria-pressed="false">忍</button>
+    <button type="button" class="btn btn-outline-light" data-graphic-mode="i" aria-pressed="false">意</button>
   </div>
+  <div id="dev-version-inline" class="dev-version-inline" aria-live="polite"></div>
 
   <div id="overlay" role="presentation">
     <div id="taglines"></div>
@@ -197,7 +196,7 @@
     <div class="tech-footer-line">GitHub Pages</div>
     <div class="tech-footer-line">Vanilla JS · ES Modules</div>
     <div class="tech-footer-line">Three.js · Bootstrap</div>
-    <div id="dev-version-inline" class="tech-footer-line"></div>
+    <div id="footer-signature" class="footer-signature">Project Designer: pjdhiro</div>
   </footer>
 
   <div class="offcanvas offcanvas-end offcanvas-kesson" tabindex="-1" id="articlesOffcanvas" data-bs-backdrop="true">

--- a/src/main.js
+++ b/src/main.js
@@ -30,8 +30,8 @@ import { detectLang } from './i18n.js';
 const DEV_MODE = new URLSearchParams(window.location.search).has('dev');
 let devStatsBegin = () => {};
 let devStatsEnd = () => {};
-const GRAPHIC_MODE_DEFAULT = 'hold';
-const GRAPHIC_MODE_OPTIONS = new Set(['hold', 'wabi', 'intent']);
+const GRAPHIC_MODE_DEFAULT = 'hoji';
+const GRAPHIC_MODE_OPTIONS = new Set(['hoji', 'sinobi', 'i']);
 const DEV_PANEL_STATE_STORAGE_PREFIX = 'creation-dev-panel-state-v1';
 
 function getSceneStateStorageKey(sceneVariant) {
@@ -106,7 +106,7 @@ const STRINGS = {
         ],
         topbarMainTitle: '創造とは',
         topbarSubtitle: 'Creation Space',
-        topbarHome: 'HOME',
+        topbarHome: 'kesson-driven',
         topbarDev: 'DEV',
         topbarArticles: 'ARTICLES',
         topbarBlog: 'BLOG',
@@ -129,7 +129,7 @@ const STRINGS = {
         ],
         topbarMainTitle: 'What Is Creation',
         topbarSubtitle: 'Creation Space',
-        topbarHome: 'HOME',
+        topbarHome: 'kesson-driven',
         topbarDev: 'DEV',
         topbarArticles: 'ARTICLES',
         topbarBlog: 'BLOG',
@@ -168,7 +168,7 @@ function applyPageLanguage(lang) {
     const topbarArticlesBtn = document.getElementById('topbar-articles-btn');
     const topbarBlogLink = document.getElementById('topbar-blog-link');
     const topbarCollab = document.getElementById('credit-collab');
-    const creditSignature = document.getElementById('credit-signature');
+    const footerSignature = document.getElementById('footer-signature');
     const articlesSectionHeading = document.getElementById('articles-section-heading');
     const offcanvasArticlesTitle = document.getElementById('offcanvas-articles-title');
     const creationCardsHeading = document.getElementById('creation-cards-heading');
@@ -183,7 +183,7 @@ function applyPageLanguage(lang) {
     if (topbarArticlesBtn) topbarArticlesBtn.textContent = strings.topbarArticles;
     if (topbarBlogLink) topbarBlogLink.textContent = strings.topbarBlog;
     if (topbarCollab) topbarCollab.textContent = strings.topbarCollab;
-    if (creditSignature) creditSignature.textContent = strings.creditSignature;
+    if (footerSignature) footerSignature.textContent = strings.creditSignature;
     if (articlesSectionHeading) articlesSectionHeading.textContent = strings.articlesSectionHeading;
     if (offcanvasArticlesTitle) offcanvasArticlesTitle.textContent = strings.offcanvasArticlesTitle;
     if (creationCardsHeading) creationCardsHeading.textContent = strings.creationCardsHeading;
@@ -258,17 +258,16 @@ function initMobileNavAutoCollapse() {
 }
 
 function normalizeGraphicMode(mode) {
+    if (mode === 'hold') return 'hoji';
+    if (mode === 'wabi') return 'sinobi';
+    if (mode === 'intent') return 'i';
     return GRAPHIC_MODE_OPTIONS.has(mode) ? mode : GRAPHIC_MODE_DEFAULT;
 }
 
 function syncGraphicModeQuery(mode) {
     if (!window.history?.replaceState) return;
     const url = new URL(window.location.href);
-    if (mode === GRAPHIC_MODE_DEFAULT) {
-        url.searchParams.delete('graphic');
-    } else {
-        url.searchParams.set('graphic', mode);
-    }
+    url.searchParams.set('graphic', mode);
     window.history.replaceState(window.history.state, '', url.toString());
 }
 
@@ -338,33 +337,19 @@ function attachResize({ camera, renderer, composer }) {
 }
 
 function initDevVersionBadge() {
-    const existing = document.getElementById('dev-version-badge');
-    if (existing) existing.remove();
-
+    const label = document.getElementById('dev-version-inline');
+    if (!label) return;
     const params = new URLSearchParams(window.location.search);
     const queryVersion = params.get('ver');
-    const badge = document.createElement('div');
-    badge.id = 'dev-version-badge';
-    badge.textContent = queryVersion
+    label.textContent = queryVersion
         ? `開発版 ver ${DEV_VERSION} · ${queryVersion}`
         : `開発版 ver ${DEV_VERSION}`;
-    const brandWrap = document.querySelector('#kesson-topbar .topbar-brand-wrap');
-    if (brandWrap) {
-        brandWrap.appendChild(badge);
-    } else {
-        document.body.appendChild(badge);
-    }
 }
 
 function initInlineVersionLabel() {
     const label = document.getElementById('dev-version-inline');
     if (!label) return;
-
-    const params = new URLSearchParams(window.location.search);
-    const queryVersion = params.get('ver');
-    label.textContent = queryVersion
-        ? `開発ver ${DEV_VERSION} · ${queryVersion}`
-        : `開発ver ${DEV_VERSION}`;
+    label.textContent = `開発版 ver ${DEV_VERSION}`;
 }
 
 async function main() {

--- a/src/scene-presets.js
+++ b/src/scene-presets.js
@@ -557,7 +557,7 @@ export function applyScenePreset(sceneName) {
 }
 
 export function resolveSceneVariant(graphicMode) {
-    if (graphicMode === 'wabi') return 'wabi';
-    if (graphicMode === 'intent') return 'intent';
+    if (graphicMode === 'sinobi' || graphicMode === 'wabi') return 'wabi';
+    if (graphicMode === 'i' || graphicMode === 'intent') return 'intent';
     return 'hold';
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -69,6 +69,31 @@
       box-shadow: 0 6px 18px rgba(0, 0, 0, 0.26);
     }
 
+    #dev-version-inline {
+      display: inline-flex;
+      align-items: center;
+      position: fixed;
+      top: calc(var(--kesson-topbar-height) + 2.95rem);
+      left: 0.95rem;
+      z-index: 58;
+      max-width: min(92vw, 22rem);
+      padding: 0.2rem 0.48rem;
+      border-radius: 999px;
+      border: 1px solid rgba(120, 164, 235, 0.45);
+      background: rgba(8, 14, 26, 0.78);
+      color: rgba(205, 224, 255, 0.9);
+      font-size: 0.58rem;
+      letter-spacing: 0.04em;
+      line-height: 1;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      pointer-events: none;
+      backdrop-filter: blur(7px);
+      -webkit-backdrop-filter: blur(7px);
+    }
+
     #graphic-switcher .btn {
       border-radius: 999px;
       border-color: rgba(130, 170, 240, 0.5);
@@ -111,6 +136,13 @@
         font-size: 0.6rem;
         min-width: 3.3rem;
         padding: 0.2rem 0.44rem;
+      }
+
+      #dev-version-inline {
+        font-size: 0.52rem;
+        top: calc(var(--kesson-topbar-height) + 2.68rem);
+        left: 0.6rem;
+        max-width: min(95vw, 17rem);
       }
     }
 
@@ -1481,4 +1513,12 @@
       font-family: 'SF Mono', 'Consolas', 'Monaco', monospace;
       letter-spacing: 0.06em;
       line-height: 1.8;
+    }
+    .footer-signature {
+      margin-top: 0.55rem;
+      font-size: clamp(0.55rem, 1.8vmin, 0.72rem);
+      color: rgba(195, 214, 241, 0.68);
+      font-family: 'Georgia', "Noto Serif JP", serif;
+      letter-spacing: 0.06em;
+      line-height: 1.5;
     }


### PR DESCRIPTION
## Summary
This PR applies the navigation-related follow-up updates discussed in the latest session.

### Navigation/UI updates
- Change topbar home label text from `HOME` to `kesson-driven`
- Remove crowded topbar metadata (`Creation Space` subtitle and topbar signature)
- Move signature to footer: `Project Designer: pjdhiro`

### Link updates
- `kesson-driven` link changed to relative path: `../kesson-space/`
- Top-left title link changed to relative path: `./`
- Remove `target="_blank"` from top-left title link (same-tab navigation)

### Dev version label placement
- Remove footer dev-version slot
- Place `開発版 ver ...` label under the graphic mode toggle (`保持 / 忍 / 意`)
- Keep one display location only

### Graphic query parameter update
- Rename outward query values:
  - `graphic=hoji`
  - `graphic=sinobi`
  - `graphic=i`
- Keep backward compatibility for old values (`hold/wabi/intent`) by normalizing them internally

## Files changed
- `index.html`
- `src/main.js`
- `src/scene-presets.js`
- `src/styles/main.css`

Refs: #5