### PR TITLE
feat(typography): topbar フォントサイズUI統合、reports 独立コントロール廃止

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,13 @@
               BLOG
             </a>
           </li>
+          <li class="nav-item">
+            <div class="btn-group btn-group-sm topbar-font-size-ctrl" role="group" aria-label="文字サイズ調整">
+              <button type="button" class="btn topbar-font-btn" id="font-size-down" aria-label="文字を小さく">A-</button>
+              <button type="button" class="btn topbar-font-btn" id="font-size-reset" aria-label="文字サイズをリセット" disabled>↺</button>
+              <button type="button" class="btn topbar-font-btn" id="font-size-up" aria-label="文字を大きく">A+</button>
+            </div>
+          </li>
           <li class="nav-item topbar-lang-item">
             <button
               type="button"
@@ -221,12 +228,6 @@
         <div class="reports-overview mb-3">
           <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2" id="reports-primary-actions">
             <button id="reports-open-status-btn" type="button" class="btn btn-outline-light btn-sm reports-status-cta">調査内容</button>
-            <div id="reports-font-controls" class="reports-font-controls" role="group" aria-label="領域別レポートの文字サイズ">
-              <span id="reports-font-controls-label" class="reports-font-controls-label">文字サイズ: +0</span>
-              <button id="reports-font-decrease-btn" type="button" class="btn btn-outline-light btn-sm" data-font-step-action="decrease" aria-label="領域別レポートの文字を小さくする">A-</button>
-              <button id="reports-font-reset-btn" type="button" class="btn btn-outline-light btn-sm" data-font-step-action="reset" aria-label="領域別レポートの文字サイズを標準に戻す">A</button>
-              <button id="reports-font-increase-btn" type="button" class="btn btn-outline-light btn-sm" data-font-step-action="increase" aria-label="領域別レポートの文字を大きくする">A+</button>
-            </div>
           </div>
           <div id="reports-metrics" class="row g-2" aria-live="polite"></div>
         </div>

--- a/src/font-size-ctrl.js
+++ b/src/font-size-ctrl.js
@@ -1,0 +1,84 @@
+// font-size-ctrl.js -- creation-space
+// CHANGED(2026-03-07): topbar A-/↺/A+ 統合 (kesson-space #114 互換)
+
+const STEP_REM = 0.1;
+const MIN_STEP = -1;
+const MAX_STEP = 4;
+const STORAGE_KEY = 'kesson-font-step';
+
+const FONT_VARS = {
+    '--kesson-font-size-ui-xs': 0.65,
+    '--kesson-font-size-ui-sm': 0.70,
+};
+
+const CLASS_VARS = {
+    '--ks-section-heading': 0.75,
+    '--ks-card-title': 0.80,
+    '--ks-card-text': 0.70,
+    '--ks-card-summary': 0.68,
+    '--ks-overlay-tagline': 0.55,
+    '--ks-overlay-tagline-en': 0.48,
+    '--ks-control-guide': 0.45,
+    '--ks-footer-line': 0.45,
+};
+
+function normalizeStep(step) {
+    const parsed = Number.parseInt(String(step), 10);
+    if (!Number.isFinite(parsed)) return 0;
+    return Math.min(MAX_STEP, Math.max(MIN_STEP, parsed));
+}
+
+function getCurrentStep() {
+    try {
+        return normalizeStep(window.localStorage.getItem(STORAGE_KEY) ?? '0');
+    } catch {
+        return 0;
+    }
+}
+
+function setStep(step) {
+    const normalized = normalizeStep(step);
+    try {
+        window.localStorage.setItem(STORAGE_KEY, String(normalized));
+    } catch {
+        // Ignore storage failures and still apply the current session value.
+    }
+    applyStep(normalized);
+}
+
+function applyStep(step) {
+    const normalized = normalizeStep(step);
+    const root = document.documentElement;
+
+    Object.entries(FONT_VARS).forEach(([varName, base]) => {
+        root.style.setProperty(varName, `${(base + normalized * STEP_REM).toFixed(2)}rem`);
+    });
+    Object.entries(CLASS_VARS).forEach(([varName, base]) => {
+        root.style.setProperty(varName, `${(base + normalized * STEP_REM).toFixed(2)}rem`);
+    });
+
+    root.style.setProperty('--reports-font-step', `${(normalized * STEP_REM).toFixed(2)}rem`);
+
+    const down = document.getElementById('font-size-down');
+    const up = document.getElementById('font-size-up');
+    const reset = document.getElementById('font-size-reset');
+    if (down) down.disabled = normalized <= MIN_STEP;
+    if (up) up.disabled = normalized >= MAX_STEP;
+    if (reset) reset.disabled = normalized === 0;
+}
+
+export function initFontSizeCtrl() {
+    applyStep(getCurrentStep());
+
+    document.getElementById('font-size-down')?.addEventListener('click', () => {
+        const current = getCurrentStep();
+        if (current > MIN_STEP) setStep(current - 1);
+    });
+    document.getElementById('font-size-up')?.addEventListener('click', () => {
+        const current = getCurrentStep();
+        if (current < MAX_STEP) setStep(current + 1);
+    });
+    document.getElementById('font-size-reset')?.addEventListener('click', () => {
+        setStep(0);
+    });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,10 +2,12 @@ import { DEV_VERSION } from './version.js';
 import { installStartupErrorHandlers, showStartupErrorOverlay } from './startup-error-overlay.js';
 import { createMainRuntimeContext } from './main-runtime-context.js';
 import { runMainOrchestrator } from './main-orchestrator.js';
+import { initFontSizeCtrl } from './font-size-ctrl.js';
 
 installStartupErrorHandlers();
 
 function startMainApp() {
+    initFontSizeCtrl();
     const runtimeContext = createMainRuntimeContext();
     return runMainOrchestrator({
         runtimeContext,

--- a/src/reports.js
+++ b/src/reports.js
@@ -10,10 +10,6 @@ const DEFAULT_REPORTS_DATA_URL = `${PJDHIRO_CREATION_RAW}/manifests/domains.json
 const DEFAULT_REPORTS_ASSET_BASE = `${PJDHIRO_CREATION_PAGES}/`;
 const DEFAULT_REPORTS_MD_ASSET_BASE = `${PJDHIRO_CREATION_RAW}/`;
 const REPORTS_SCENARIO_BASE = 'assets/reports/scenarios';
-const REPORTS_FONT_STEP_STORAGE_KEY = 'creation-space:reports-font-step';
-const REPORTS_FONT_STEP_DEFAULT = 0;
-const REPORTS_FONT_STEP_MIN = -1;
-const REPORTS_FONT_STEP_MAX = 4;
 const STATUS_REPORT_LINKS = {
     ja: {
         mdUrl: `${PJDHIRO_CREATION_RAW}/survey/ja/md/survey-status.md`,
@@ -121,14 +117,6 @@ const STRINGS = {
         tabDomains: '領域別レポート',
         tabModels: 'モデル解説',
         filterGroupAria: '領域別レポート絞り込み',
-        fontControlsAria: '領域別レポートの文字サイズ',
-        fontSizeLabel: '文字サイズ',
-        fontSizeDecrease: 'A-',
-        fontSizeReset: 'A',
-        fontSizeIncrease: 'A+',
-        fontSizeDecreaseAria: '領域別レポートの文字を小さくする',
-        fontSizeResetAria: '領域別レポートの文字サイズを標準に戻す',
-        fontSizeIncreaseAria: '領域別レポートの文字を大きくする',
         filterAll: '全件',
         openStatus: '調査内容',
         statusReportTitle: '調査概要',
@@ -175,14 +163,6 @@ const STRINGS = {
         tabDomains: 'Domain Reports',
         tabModels: 'Model Guides',
         filterGroupAria: 'Filter domain reports',
-        fontControlsAria: 'Text size for domain reports',
-        fontSizeLabel: 'Text size',
-        fontSizeDecrease: 'A-',
-        fontSizeReset: 'A',
-        fontSizeIncrease: 'A+',
-        fontSizeDecreaseAria: 'Decrease text size for domain reports',
-        fontSizeResetAria: 'Reset text size for domain reports',
-        fontSizeIncreaseAria: 'Increase text size for domain reports',
         filterAll: 'All',
         openStatus: 'Investigation Notes',
         statusReportTitle: 'Survey Overview',
@@ -227,7 +207,6 @@ const state = {
     progressLevelCounts: {},
     activeScenario: null,
     tableFilter: 'all',
-    reportsFontStep: REPORTS_FONT_STEP_DEFAULT,
     loadError: false,
     dataUrl: DEFAULT_REPORTS_DATA_URL,
     assetBaseUrl: DEFAULT_REPORTS_ASSET_BASE,
@@ -236,14 +215,8 @@ const state = {
     mdRequestId: 0,
     quickLinksBound: false,
     dom: {
-        section: null,
         error: null,
         openStatusBtn: null,
-        fontControls: null,
-        fontControlsLabel: null,
-        fontDecreaseBtn: null,
-        fontResetBtn: null,
-        fontIncreaseBtn: null,
         domainsHeading: null,
         modelsHeading: null,
         scenarioNote: null,
@@ -286,73 +259,6 @@ function formatReportsScenarioFallbackLabel(name) {
 
 function hasText(value) {
     return typeof value === 'string' && value.trim().length > 0;
-}
-
-function normalizeReportsFontStep(value) {
-    const parsed = Number.parseInt(String(value), 10);
-    if (!Number.isFinite(parsed)) return REPORTS_FONT_STEP_DEFAULT;
-    return Math.min(REPORTS_FONT_STEP_MAX, Math.max(REPORTS_FONT_STEP_MIN, parsed));
-}
-
-function loadStoredReportsFontStep() {
-    try {
-        return normalizeReportsFontStep(window.localStorage?.getItem(REPORTS_FONT_STEP_STORAGE_KEY));
-    } catch {
-        return REPORTS_FONT_STEP_DEFAULT;
-    }
-}
-
-function persistReportsFontStep(step) {
-    try {
-        window.localStorage?.setItem(REPORTS_FONT_STEP_STORAGE_KEY, String(normalizeReportsFontStep(step)));
-    } catch {
-        // Ignore storage failures and keep the in-memory value.
-    }
-}
-
-function getReportsFontStepStateLabel() {
-    const normalized = normalizeReportsFontStep(state.reportsFontStep);
-    return normalized >= 0 ? `+${normalized}` : String(normalized);
-}
-
-function updateReportsFontControls() {
-    const strings = getStrings(state.lang);
-
-    if (state.dom.fontControls) {
-        state.dom.fontControls.setAttribute('aria-label', strings.fontControlsAria);
-    }
-    if (state.dom.fontControlsLabel) {
-        state.dom.fontControlsLabel.textContent = `${strings.fontSizeLabel}: ${getReportsFontStepStateLabel()}`;
-    }
-    if (state.dom.fontDecreaseBtn) {
-        state.dom.fontDecreaseBtn.textContent = strings.fontSizeDecrease;
-        state.dom.fontDecreaseBtn.setAttribute('aria-label', strings.fontSizeDecreaseAria);
-        state.dom.fontDecreaseBtn.disabled = state.reportsFontStep <= REPORTS_FONT_STEP_MIN;
-    }
-    if (state.dom.fontResetBtn) {
-        state.dom.fontResetBtn.textContent = strings.fontSizeReset;
-        state.dom.fontResetBtn.setAttribute('aria-label', strings.fontSizeResetAria);
-        state.dom.fontResetBtn.disabled = state.reportsFontStep === REPORTS_FONT_STEP_DEFAULT;
-    }
-    if (state.dom.fontIncreaseBtn) {
-        state.dom.fontIncreaseBtn.textContent = strings.fontSizeIncrease;
-        state.dom.fontIncreaseBtn.setAttribute('aria-label', strings.fontSizeIncreaseAria);
-        state.dom.fontIncreaseBtn.disabled = state.reportsFontStep >= REPORTS_FONT_STEP_MAX;
-    }
-}
-
-function applyReportsFontStep() {
-    if (state.dom.section) {
-        state.dom.section.setAttribute('data-reports-font-step', String(state.reportsFontStep));
-    }
-    updateReportsFontControls();
-}
-
-function setReportsFontStep(nextStep) {
-    const normalized = normalizeReportsFontStep(nextStep);
-    state.reportsFontStep = normalized;
-    persistReportsFontStep(normalized);
-    applyReportsFontStep();
 }
 
 function normalizeProgressLevelId(value) {
@@ -887,14 +793,8 @@ function sortReportsById(list) {
 }
 
 function cacheDom() {
-    state.dom.section = document.getElementById('reports-section');
     state.dom.error = document.getElementById('reports-error');
     state.dom.openStatusBtn = document.getElementById('reports-open-status-btn');
-    state.dom.fontControls = document.getElementById('reports-font-controls');
-    state.dom.fontControlsLabel = document.getElementById('reports-font-controls-label');
-    state.dom.fontDecreaseBtn = document.getElementById('reports-font-decrease-btn');
-    state.dom.fontResetBtn = document.getElementById('reports-font-reset-btn');
-    state.dom.fontIncreaseBtn = document.getElementById('reports-font-increase-btn');
     state.dom.domainsHeading = document.getElementById('reports-domains-heading');
     state.dom.modelsHeading = document.getElementById('reports-models-heading');
     state.dom.scenarioNote = document.getElementById('reports-scenario-note');
@@ -1218,29 +1118,6 @@ function bindQuickLinks() {
         state.dom.filterGroup.dataset.boundClick = '1';
     }
 
-    if (state.dom.fontControls && !state.dom.fontControls.dataset.boundClick) {
-        state.dom.fontControls.addEventListener('click', (event) => {
-            const target = event.target;
-            if (!(target instanceof HTMLElement)) return;
-            const button = target.closest('button[data-font-step-action]');
-            if (!(button instanceof HTMLButtonElement)) return;
-
-            const action = button.dataset.fontStepAction;
-            if (action === 'decrease') {
-                setReportsFontStep(state.reportsFontStep - 1);
-                return;
-            }
-            if (action === 'increase') {
-                setReportsFontStep(state.reportsFontStep + 1);
-                return;
-            }
-            if (action === 'reset') {
-                setReportsFontStep(REPORTS_FONT_STEP_DEFAULT);
-            }
-        });
-        state.dom.fontControls.dataset.boundClick = '1';
-    }
-
     state.quickLinksBound = true;
 }
 
@@ -1314,7 +1191,6 @@ function applyStaticText() {
 
     if (state.dom.filterGroup) state.dom.filterGroup.setAttribute('aria-label', strings.filterGroupAria);
     if (state.dom.openStatusBtn) state.dom.openStatusBtn.textContent = strings.openStatus;
-    updateReportsFontControls();
     updateFilterButtons();
 
     if (state.dom.mdCloseBtn) state.dom.mdCloseBtn.textContent = strings.modalClose;
@@ -1581,8 +1457,6 @@ export async function initReports({
     assetMdBaseUrl = DEFAULT_REPORTS_MD_ASSET_BASE,
 } = {}) {
     cacheDom();
-    state.reportsFontStep = loadStoredReportsFontStep();
-    applyReportsFontStep();
     bindQuickLinks();
 
     state.lang = normalizeLang(lang);
@@ -1615,6 +1489,5 @@ export async function initReports({
 
 export function setReportsLanguage(lang) {
     state.lang = normalizeLang(lang);
-    updateReportsFontControls();
     renderReports();
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -28,6 +28,17 @@
       --kesson-card-bg: rgba(20, 25, 40, 0.9);
       --kesson-offcanvas-width: 85%;
       --kesson-offcanvas-bg: rgba(10, 14, 26, 0.98);
+      --kesson-font-size-ui-xs: clamp(0.4rem, 1.8vmin, 0.65rem);
+      --kesson-font-size-ui-sm: clamp(0.5rem, 2.2vmin, 0.7rem);
+      --ks-section-heading: 0.75rem;
+      --ks-card-title: 0.8rem;
+      --ks-card-text: 0.7rem;
+      --ks-card-summary: 0.68rem;
+      --ks-overlay-tagline: clamp(0.5rem, 2.4vmin, 0.85rem);
+      --ks-overlay-tagline-en: clamp(0.4rem, 2.0vmin, 0.75rem);
+      --ks-control-guide: clamp(0.35rem, 1.6vmin, 0.55rem);
+      --ks-footer-line: clamp(0.35rem, 1.5vmin, 0.55rem);
+      --reports-font-step: 0rem;
       --kesson-topbar-height: 3.25rem;
       --kesson-topbar-alpha-strong: 0.10;
       --kesson-topbar-alpha-soft: 0.10;
@@ -396,6 +407,27 @@
       pointer-events: none;
       user-select: none;
     }
+    .topbar-font-size-ctrl {
+      opacity: 0.75;
+    }
+    .topbar-font-btn {
+      font-family: var(--reports-font-mono, 'SF Mono', 'Fira Code', 'Consolas', monospace);
+      font-size: 0.6rem;
+      letter-spacing: 0.08em;
+      padding: 0.2rem 0.5rem;
+      background: transparent;
+      border: 1px solid rgba(130, 170, 240, 0.2);
+      color: rgba(205, 220, 244, 0.7);
+      line-height: 1.4;
+    }
+    .topbar-font-btn:hover:not(:disabled) {
+      background: rgba(120, 165, 240, 0.15);
+      color: rgba(236, 244, 255, 0.9);
+    }
+    .topbar-font-btn:disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
     #kesson-topbar .topbar-toggler {
       border-color: rgba(145, 178, 242, 0.55);
       padding: 0.18rem 0.44rem;
@@ -590,7 +622,7 @@
     }
 
     .tagline {
-      font-size: clamp(0.5rem, 2.4vmin, 0.85rem);
+      font-size: var(--ks-overlay-tagline, clamp(0.5rem, 2.4vmin, 0.85rem));
       color: rgba(var(--color-heading), 0.75);
       font-family: "Noto Serif JP", "Yu Mincho", "MS PMincho", serif;
       letter-spacing: 0.05em;
@@ -599,7 +631,7 @@
     }
 
     .tagline-en {
-      font-size: clamp(0.4rem, 2.0vmin, 0.75rem);
+      font-size: var(--ks-overlay-tagline-en, clamp(0.4rem, 2.0vmin, 0.75rem));
       color: rgba(var(--color-heading), 0.55);
       font-family: 'Georgia', serif;
       letter-spacing: 0.03em;
@@ -793,7 +825,7 @@
       margin-bottom: 3px;
     }
     #control-guide .guide-key {
-      font-size: clamp(0.35rem, 1.6vmin, 0.55rem);
+      font-size: var(--ks-control-guide, clamp(0.35rem, 1.6vmin, 0.55rem));
       color: rgba(var(--color-sub-text), 0.35);
       font-family: 'SF Mono', 'Consolas', 'Monaco', monospace;
       letter-spacing: 0.03em;
@@ -804,7 +836,7 @@
       color: rgba(var(--color-sub-text), 0.2);
     }
     #control-guide .guide-action {
-      font-size: clamp(0.35rem, 1.6vmin, 0.55rem);
+      font-size: var(--ks-control-guide, clamp(0.35rem, 1.6vmin, 0.55rem));
       color: rgba(var(--color-sub-text), 0.3);
       font-family: 'Georgia', serif;
       letter-spacing: 0.06em;
@@ -899,15 +931,15 @@
     }
     .kesson-card .card-title {
       color: #fff;
-      font-size: 0.8rem;
+      font-size: var(--ks-card-title, 0.8rem);
     }
     .kesson-card .card-body small {
       color: rgba(var(--color-heading), 0.5);
-      font-size: 0.7rem;
+      font-size: var(--ks-card-text, 0.7rem);
     }
     .kesson-card .card-text {
       color: rgba(var(--color-heading), 0.5);
-      font-size: 0.7rem;
+      font-size: var(--ks-card-text, 0.7rem);
     }
 
     /* 無限スクロールローディング */
@@ -1010,7 +1042,7 @@
 
     /* Section heading — monospace, all-caps */
     .section-heading {
-      font-size: 0.75rem;
+      font-size: var(--ks-section-heading, 0.75rem);
       font-weight: 400;
       color: rgba(var(--color-sub-text), 0.5);
       letter-spacing: 0.15em;
@@ -1676,7 +1708,7 @@
       pointer-events: none;
     }
     .tech-footer-line {
-      font-size: clamp(0.35rem, 1.5vmin, 0.55rem);
+      font-size: var(--ks-footer-line, clamp(0.35rem, 1.5vmin, 0.55rem));
       color: rgba(150, 175, 210, 0.25);
       font-family: 'SF Mono', 'Consolas', 'Monaco', monospace;
       letter-spacing: 0.06em;
@@ -1705,7 +1737,6 @@
   position: relative;
   z-index: 5;
   padding-bottom: 1.2rem;
-  --reports-font-step: 0rem;
   --reports-font-mono: 'SF Mono', 'Fira Code', 'Consolas', monospace;
   --reports-border-soft: rgba(var(--color-accent), 0.12);
   --reports-border-base: rgba(var(--color-accent), 0.2);
@@ -1723,26 +1754,6 @@
     calc(0.84rem + var(--reports-font-step))
   );
   --reports-control-letter-spacing: 0.06em;
-}
-
-#reports-section[data-reports-font-step="-1"] {
-  --reports-font-step: -0.1rem;
-}
-
-#reports-section[data-reports-font-step="1"] {
-  --reports-font-step: 0.1rem;
-}
-
-#reports-section[data-reports-font-step="2"] {
-  --reports-font-step: 0.2rem;
-}
-
-#reports-section[data-reports-font-step="3"] {
-  --reports-font-step: 0.3rem;
-}
-
-#reports-section[data-reports-font-step="4"] {
-  --reports-font-step: 0.4rem;
 }
 
 #reports-primary-actions .btn,
@@ -1843,25 +1854,6 @@
 .reports-level-legend-label {
   font-weight: 700;
   color: rgba(var(--color-heading), 0.88);
-}
-
-.reports-font-controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.35rem;
-}
-
-.reports-font-controls-label {
-  color: rgba(var(--color-sub-text), 0.78);
-  font-family: var(--reports-font-mono);
-  font-size: calc(0.72rem + var(--reports-font-step));
-  letter-spacing: 0.05em;
-}
-
-.reports-font-controls .btn {
-  min-width: 2.9rem;
 }
 
 #reports-primary-actions .btn:disabled,


### PR DESCRIPTION
## Summary
- add topbar A-/↺/A+ font size controls based on kesson-space
- remove the standalone reports font controls and keep reports driven by the shared root variable
- move typography scaling into src/font-size-ctrl.js and variableize shared creation-space text sizes

## Testing
- node --check src/main.js
- node --check src/reports.js
- node --check src/font-size-ctrl.js
- curl -I http://127.0.0.1:3003/

## Note
- visual verification and merge are pending pjdhiro confirmation
- refs #26