### PR TITLE
fix(cs#236): cs styles の --kesson-* 全廃 (techo#128 Phase 1b)

### DIFF
--- a/dev-components.html
+++ b/dev-components.html
@@ -33,13 +33,13 @@
     }
 
     a {
-      color: var(--kesson-md-link);
+      color: var(--cs-md-link);
     }
 
     code,
     pre,
     .ds-mono {
-      font-family: var(--kesson-font-mono-ui);
+      font-family: var(--ds-font-mono-ui);
     }
 
     .ds-hero {
@@ -286,7 +286,7 @@
       justify-content: center;
       gap: 0.35rem;
       text-decoration: none;
-      border-radius: var(--kesson-radius-sm);
+      border-radius: var(--ds-radius-sm);
       border: 1px solid transparent;
       padding: 0.48rem 0.9rem;
       cursor: pointer;
@@ -308,7 +308,7 @@
     }
 
     .card {
-      border-radius: var(--kesson-radius-lg);
+      border-radius: var(--ds-radius-lg);
       overflow: hidden;
     }
 
@@ -340,7 +340,7 @@
 
     .form-control:focus,
     .form-select:focus {
-      outline: 2px solid var(--kesson-focus-ring-soft);
+      outline: 2px solid var(--ds-focus-ring-soft);
       outline-offset: 2px;
     }
 
@@ -467,21 +467,21 @@
     }
 
     .ds-action-button {
-      background: var(--kesson-action-bg);
-      border: 1px solid var(--kesson-action-border);
-      color: var(--kesson-action-text);
-      font-family: var(--kesson-font-serif-ui);
-      letter-spacing: var(--kesson-letter-ui-wide);
+      background: var(--cs-action-bg);
+      border: 1px solid var(--cs-action-border);
+      color: var(--cs-action-text);
+      font-family: var(--ds-font-serif-ui);
+      letter-spacing: var(--ds-letter-ui-wide);
       transition:
-        background var(--kesson-transition-standard),
-        color var(--kesson-transition-standard);
+        background var(--ds-transition-standard),
+        color var(--ds-transition-standard);
     }
 
     .ds-action-button:hover,
     .ds-action-button:focus-visible {
-      background: var(--kesson-action-bg-hover);
-      color: var(--kesson-action-text-hover);
-      outline: 2px solid var(--kesson-focus-ring-soft);
+      background: var(--cs-action-bg-hover);
+      color: var(--cs-action-text-hover);
+      outline: 2px solid var(--ds-focus-ring-soft);
       outline-offset: 2px;
     }
 
@@ -496,11 +496,11 @@
       align-items: center;
       padding: 0.48rem 0.8rem;
       border-radius: 0.45rem;
-      background: var(--kesson-dev-toggle-bg);
-      border: 1px solid var(--kesson-dev-toggle-border);
+      background: var(--cs-dev-toggle-bg);
+      border: 1px solid var(--cs-dev-toggle-border);
       color: rgba(180, 200, 255, 0.75);
       font-size: 0.62rem;
-      font-family: var(--kesson-font-mono-ui);
+      font-family: var(--ds-font-mono-ui);
       letter-spacing: 0.1em;
     }
 
@@ -520,7 +520,7 @@
     }
 
     .ds-offcanvas-demo a {
-      color: var(--kesson-offcanvas-link);
+      color: var(--cs-offcanvas-link);
     }
 
     .ds-viewer-host #kesson-viewer {
@@ -531,7 +531,7 @@
       border-radius: 0.9rem;
       overflow: hidden;
       cursor: default;
-      background: var(--kesson-viewer-overlay-open);
+      background: var(--cs-viewer-overlay-open);
     }
 
     .ds-viewer-host .viewer-glass {
@@ -541,8 +541,8 @@
       margin: 1.2rem auto;
       opacity: 1;
       transform: none;
-      background: var(--kesson-viewer-glass-bg);
-      border-color: var(--kesson-viewer-glass-border);
+      background: var(--cs-viewer-glass-bg);
+      border-color: var(--cs-viewer-glass-border);
     }
 
     .ds-viewer-host .viewer-close {
@@ -581,8 +581,8 @@
     }
 
     .ds-error {
-      color: var(--kesson-error-color);
-      font-size: var(--kesson-error-size);
+      color: var(--ds-error-color);
+      font-size: var(--ds-error-size);
     }
 
     .ds-report-palette {
@@ -603,13 +603,13 @@
     }
 
     #reports-demo-scope {
-      --reports-font-mono: var(--kesson-font-mono-ui);
-      --reports-font-serif: var(--kesson-font-serif-ui);
+      --reports-font-mono: var(--ds-font-mono-ui);
+      --reports-font-serif: var(--ds-font-serif-ui);
       --reports-panel-radius: 0.5rem;
       --reports-panel-padding: 0.9rem;
       --reports-stack-gap: 0.9rem;
-      --reports-panel-shadow: var(--kesson-card-shadow-soft);
-      --reports-panel-shadow-hover: var(--kesson-card-shadow-rich);
+      --reports-panel-shadow: var(--ds-card-shadow-soft);
+      --reports-panel-shadow-hover: var(--ds-card-shadow-rich);
       --reports-border-soft: rgba(var(--color-accent), 0.12);
       --reports-border-base: rgba(var(--color-accent), 0.2);
       --reports-border-strong: rgba(var(--color-accent), 0.35);
@@ -625,7 +625,7 @@
         calc(2.2vmin + var(--reports-font-step)),
         calc(0.74rem + var(--reports-font-step))
       );
-      --reports-control-letter-spacing: var(--kesson-letter-ui-normal);
+      --reports-control-letter-spacing: var(--ds-letter-ui-normal);
       --reports-palette-1-rgb: 157, 172, 194;
       --reports-palette-2-rgb: 241, 190, 82;
       --reports-palette-3-rgb: 92, 145, 255;
@@ -693,7 +693,7 @@
   </style>
 </head>
 <body style="background: var(--color-bg-body); color: rgba(var(--color-sub-text), 0.8); padding: 0 1.5rem 4rem;">
-  <nav style="position: sticky; top: 0; z-index: 1000; display: flex; align-items: center; gap: 1.2rem; padding: 0.5rem 1.2rem; margin: 0 -1.5rem 1rem; background: linear-gradient(180deg, rgba(var(--color-accent), 0.14), rgba(var(--color-accent), 0.06)); border-bottom: 1px solid rgba(var(--color-accent), 0.18); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); font-family: var(--kesson-font-serif-ui); font-size: 0.72rem; letter-spacing: 0.06em;">
+  <nav style="position: sticky; top: 0; z-index: 1000; display: flex; align-items: center; gap: 1.2rem; padding: 0.5rem 1.2rem; margin: 0 -1.5rem 1rem; background: linear-gradient(180deg, rgba(var(--color-accent), 0.14), rgba(var(--color-accent), 0.06)); border-bottom: 1px solid rgba(var(--color-accent), 0.18); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); font-family: var(--ds-font-serif-ui); font-size: 0.72rem; letter-spacing: 0.06em;">
     <a href="./" style="color: rgba(var(--color-heading), 0.82); text-decoration: none; font-weight: 600;">Home</a>
     <a href="./?dev" style="color: rgba(var(--color-highlight), 0.68); text-decoration: none;">Main (?dev)</a>
     <span style="color: rgba(var(--color-highlight), 0.92); font-weight: 600; border-bottom: 1px solid rgba(var(--color-highlight), 0.5);">Design System</span>
@@ -709,27 +709,27 @@
         <article class="ds-summary-card">
           <strong>22</strong>
           <span>カラーパレット</span>
-          <code>--color-*</code> / <code>--kesson-md-*</code> / <code>--kesson-error-*</code>
+          <code>--color-*</code> / <code>--cs-md-*</code> / <code>--cs-error-*</code>
         </article>
         <article class="ds-summary-card">
           <strong>51</strong>
           <span>タイポグラフィ</span>
-          <code>--kesson-font-*</code> / <code>--kesson-letter-*</code> / <code>--kesson-topbar-*</code>
+          <code>--cs-font-*</code> / <code>--cs-letter-*</code> / <code>--cs-topbar-*</code>
         </article>
         <article class="ds-summary-card">
           <strong>14</strong>
           <span>スペーシング・レイアウト</span>
-          <code>--kesson-radius-*</code> / <code>--kesson-transition-*</code> / <code>--kesson-topbar-*</code>
+          <code>--cs-radius-*</code> / <code>--cs-transition-*</code> / <code>--cs-topbar-*</code>
         </article>
         <article class="ds-summary-card">
           <strong>22</strong>
           <span>コンポーネント表層</span>
-          <code>--kesson-card-*</code> / <code>--kesson-offcanvas-*</code> / <code>--kesson-viewer-*</code>
+          <code>--cs-card-*</code> / <code>--cs-offcanvas-*</code> / <code>--cs-viewer-*</code>
         </article>
         <article class="ds-summary-card">
           <strong>6 + 1</strong>
           <span>UI部品 + Reports橋渡し</span>
-          <code>--kesson-ui-*</code> / <code>--kesson-focus-*</code> / <code>--reports-font-step</code>
+          <code>--cs-ui-*</code> / <code>--cs-focus-*</code> / <code>--reports-font-step</code>
         </article>
       </div>
     </section>
@@ -743,14 +743,14 @@
       <div class="ds-inline-grid">
         <div class="ds-component">
           <h3>分類ルール</h3>
-          <p>AI は prefix を起点に読むと速いです。色は <code>--color-*</code>、文字は <code>--kesson-font-*</code> と <code>--kesson-topbar-*</code>、表層は <code>--kesson-card-*</code> や <code>--reports-*</code> が担当します。</p>
+          <p>AI は prefix を起点に読むと速いです。色は <code>--color-*</code>、文字は <code>--cs-font-*</code> と <code>--cs-topbar-*</code>、表層は <code>--cs-card-*</code> や <code>--reports-*</code> が担当します。</p>
           <div>
             <span class="ds-token-pill">--color-*</span>
-            <span class="ds-token-pill">--kesson-font-*</span>
-            <span class="ds-token-pill">--kesson-card-*</span>
-            <span class="ds-token-pill">--kesson-offcanvas-*</span>
-            <span class="ds-token-pill">--kesson-viewer-*</span>
-            <span class="ds-token-pill">--kesson-ui-*</span>
+            <span class="ds-token-pill">--cs-font-*</span>
+            <span class="ds-token-pill">--cs-card-*</span>
+            <span class="ds-token-pill">--cs-offcanvas-*</span>
+            <span class="ds-token-pill">--cs-viewer-*</span>
+            <span class="ds-token-pill">--cs-ui-*</span>
             <span class="ds-token-pill">--reports-*</span>
           </div>
         </div>
@@ -758,7 +758,7 @@
           <h3>読み順</h3>
           <p>変更前は <code>docs/design-system.md</code> を読んだ上で、このページの対象コンポーネントまで飛び、下の変数テーブルから root token と local var を辿ります。</p>
           <div class="ds-table-wrap">
-            <table class="ds-variable-table" data-variable-table="--color-accent,--kesson-card-bg,--kesson-offcanvas-bg,--kesson-viewer-glass-bg,--reports-font-step">
+            <table class="ds-variable-table" data-variable-table="--color-accent,--cs-card-bg,--cs-offcanvas-bg,--cs-viewer-glass-bg,--reports-font-step">
               <tbody></tbody>
             </table>
           </div>
@@ -820,47 +820,47 @@
       </article>
 
       <!-- Component: palette-markdown -->
-      <!-- Variables: --kesson-md-provenance, --kesson-md-h1, --kesson-md-h1-strong, --kesson-md-h2, --kesson-md-h3, --kesson-md-h4, --kesson-md-link, --kesson-md-link-hover, --kesson-md-quote, --kesson-md-inline-code, --kesson-md-inline-code-bg, --kesson-md-table-head-bg, --kesson-md-table-head-text, --kesson-md-table-cell-text, --kesson-error-color -->
+      <!-- Variables: --cs-md-provenance, --cs-md-h1, --cs-md-h1-strong, --cs-md-h2, --cs-md-h3, --cs-md-h4, --cs-md-link, --cs-md-link-hover, --cs-md-quote, --cs-md-inline-code, --cs-md-inline-code-bg, --cs-md-table-head-bg, --cs-md-table-head-text, --cs-md-table-cell-text, --ds-error-color -->
       <!-- Intent: Markdown 表示とエラー表示の色をコンポーネント横断で確認する -->
-      <article class="ds-component" data-component="palette-markdown" data-source="src/styles/shell.css src/styles/viewer.css src/styles/articles.css" data-variables="--kesson-md-provenance,--kesson-md-h1,--kesson-md-h1-strong,--kesson-md-h2,--kesson-md-h3,--kesson-md-h4,--kesson-md-link,--kesson-md-link-hover,--kesson-md-quote,--kesson-md-inline-code,--kesson-md-inline-code-bg,--kesson-md-table-head-bg,--kesson-md-table-head-text,--kesson-md-table-cell-text,--kesson-error-color">
+      <article class="ds-component" data-component="palette-markdown" data-source="src/styles/shell.css src/styles/viewer.css src/styles/articles.css" data-variables="--cs-md-provenance,--cs-md-h1,--cs-md-h1-strong,--cs-md-h2,--cs-md-h3,--cs-md-h4,--cs-md-link,--cs-md-link-hover,--cs-md-quote,--cs-md-inline-code,--cs-md-inline-code-bg,--cs-md-table-head-bg,--cs-md-table-head-text,--cs-md-table-cell-text,--ds-error-color">
         <h3>Markdown + Error Colors</h3>
         <p>Markdown 本文と異常表示の色です。現状の CSS では viewer 側に同値の直書きも残っているため、ここは将来的な集約候補です。</p>
         <div class="ds-demo-shell">
           <div class="ds-swatch-grid">
             <div class="ds-swatch">
-              <div class="ds-swatch-chip" style="background: var(--kesson-md-h1);"></div>
+              <div class="ds-swatch-chip" style="background: var(--cs-md-h1);"></div>
               <strong>MD H1</strong>
-              <code>--kesson-md-h1</code>
+              <code>--cs-md-h1</code>
             </div>
             <div class="ds-swatch">
-              <div class="ds-swatch-chip" style="background: var(--kesson-md-h2);"></div>
+              <div class="ds-swatch-chip" style="background: var(--cs-md-h2);"></div>
               <strong>MD H2</strong>
-              <code>--kesson-md-h2</code>
+              <code>--cs-md-h2</code>
             </div>
             <div class="ds-swatch">
-              <div class="ds-swatch-chip" style="background: var(--kesson-md-link);"></div>
+              <div class="ds-swatch-chip" style="background: var(--cs-md-link);"></div>
               <strong>MD Link</strong>
-              <code>--kesson-md-link</code>
+              <code>--cs-md-link</code>
             </div>
             <div class="ds-swatch">
-              <div class="ds-swatch-chip" style="background: var(--kesson-md-quote);"></div>
+              <div class="ds-swatch-chip" style="background: var(--cs-md-quote);"></div>
               <strong>MD Quote</strong>
-              <code>--kesson-md-quote</code>
+              <code>--cs-md-quote</code>
             </div>
             <div class="ds-swatch">
-              <div class="ds-swatch-chip" style="background: var(--kesson-md-inline-code-bg);"></div>
+              <div class="ds-swatch-chip" style="background: var(--cs-md-inline-code-bg);"></div>
               <strong>Inline Code BG</strong>
-              <code>--kesson-md-inline-code-bg</code>
+              <code>--cs-md-inline-code-bg</code>
             </div>
             <div class="ds-swatch">
-              <div class="ds-swatch-chip" style="background: var(--kesson-error-color);"></div>
+              <div class="ds-swatch-chip" style="background: var(--ds-error-color);"></div>
               <strong>Error</strong>
-              <code>--kesson-error-color</code>
+              <code>--ds-error-color</code>
             </div>
           </div>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-md-provenance,--kesson-md-h1,--kesson-md-h1-strong,--kesson-md-h2,--kesson-md-h3,--kesson-md-h4,--kesson-md-link,--kesson-md-link-hover,--kesson-md-quote,--kesson-md-inline-code,--kesson-md-inline-code-bg,--kesson-md-table-head-bg,--kesson-md-table-head-text,--kesson-md-table-cell-text,--kesson-md-strong,--kesson-md-em,--kesson-md-pre-bg,--kesson-md-pdf-link,--kesson-md-pdf-link-hover,--kesson-md-pdf-link-hover-bg,--kesson-error-color,--kesson-error-size">
+          <table class="ds-variable-table" data-variable-table="--cs-md-provenance,--cs-md-h1,--cs-md-h1-strong,--cs-md-h2,--cs-md-h3,--cs-md-h4,--cs-md-link,--cs-md-link-hover,--cs-md-quote,--cs-md-inline-code,--cs-md-inline-code-bg,--cs-md-table-head-bg,--cs-md-table-head-text,--cs-md-table-cell-text,--cs-md-strong,--cs-md-em,--cs-md-pre-bg,--cs-md-pdf-link,--cs-md-pdf-link-hover,--cs-md-pdf-link-hover-bg,--ds-error-color,--ds-error-size">
             <tbody></tbody>
           </table>
         </div>
@@ -874,38 +874,38 @@
       </header>
 
       <!-- Component: typography-scale -->
-      <!-- Variables: --kesson-font-serif-display, --kesson-font-serif-ui, --kesson-font-mono-ui, --kesson-font-size-ui-xs, --kesson-font-size-ui-sm, --kesson-font-size-ui-arrow, --kesson-letter-ui-tight, --kesson-letter-ui-normal, --kesson-letter-ui-wide, --kesson-letter-ui-heading, --kesson-section-heading, --kesson-card-title, --kesson-card-text, --kesson-overlay-tagline, --kesson-control-guide -->
+      <!-- Variables: --ds-font-serif-display, --ds-font-serif-ui, --ds-font-mono-ui, --ds-font-size-ui-xs, --ds-font-size-ui-sm, --ds-font-size-ui-arrow, --ds-letter-ui-tight, --ds-letter-ui-normal, --ds-letter-ui-wide, --ds-letter-ui-heading, --ds-section-heading, --ds-card-title, --ds-card-text, --ds-overlay-tagline, --ds-control-guide -->
       <!-- Intent: 各文字レイヤーの担当を視覚的に切り分け、サイズ変更時の参照面にする -->
-      <article class="ds-component" data-component="typography-scale" data-source="src/styles/shell.css src/styles/topbar.css src/styles/reports.css" data-variables="--kesson-font-serif-display,--kesson-font-serif-ui,--kesson-font-mono-ui,--kesson-font-size-ui-xs,--kesson-font-size-ui-sm,--kesson-font-size-ui-arrow,--kesson-letter-ui-tight,--kesson-letter-ui-normal,--kesson-letter-ui-wide,--kesson-letter-ui-heading,--kesson-section-heading,--kesson-card-title,--kesson-card-text,--kesson-overlay-tagline,--kesson-control-guide">
+      <article class="ds-component" data-component="typography-scale" data-source="src/styles/shell.css src/styles/topbar.css src/styles/reports.css" data-variables="--ds-font-serif-display,--ds-font-serif-ui,--ds-font-mono-ui,--ds-font-size-ui-xs,--ds-font-size-ui-sm,--ds-font-size-ui-arrow,--ds-letter-ui-tight,--ds-letter-ui-normal,--ds-letter-ui-wide,--ds-letter-ui-heading,--ds-section-heading,--ds-card-title,--ds-card-text,--ds-overlay-tagline,--ds-control-guide">
         <h3>Font Families and Steps</h3>
         <p>display は見出し、UI serif は注釈・ボタン、mono は制御とメタ情報に使われています。</p>
         <div class="ds-demo-shell">
           <div class="ds-inline-grid">
-            <div class="ds-type-sample" style="font-family: var(--kesson-font-serif-display);">
+            <div class="ds-type-sample" style="font-family: var(--ds-font-serif-display);">
               <strong>Display Serif</strong>
               創造とは / Design intent / Section heading
-              <small><code>--kesson-font-serif-display</code></small>
+              <small><code>--ds-font-serif-display</code></small>
             </div>
-            <div class="ds-type-sample" style="font-family: var(--kesson-font-serif-ui);">
+            <div class="ds-type-sample" style="font-family: var(--ds-font-serif-ui);">
               <strong>UI Serif</strong>
               Actions, notes, reports explanation
-              <small><code>--kesson-font-serif-ui</code></small>
+              <small><code>--ds-font-serif-ui</code></small>
             </div>
-            <div class="ds-type-sample" style="font-family: var(--kesson-font-mono-ui);">
+            <div class="ds-type-sample" style="font-family: var(--ds-font-mono-ui);">
               <strong>Mono UI</strong>
               DEV / LABEL / A+ / D23 / 0x001
-              <small><code>--kesson-font-mono-ui</code></small>
+              <small><code>--ds-font-mono-ui</code></small>
             </div>
             <div class="ds-type-sample">
-              <strong style="font-size: var(--kesson-font-size-ui-xs); letter-spacing: var(--kesson-letter-ui-wide);">scroll / ui-xs</strong>
-              <div style="font-size: var(--kesson-font-size-ui-sm); letter-spacing: var(--kesson-letter-ui-normal);">support text / ui-sm</div>
-              <div style="font-size: var(--kesson-font-size-ui-arrow);">▾ ▴ ↺</div>
-              <small><code>--kesson-font-size-ui-xs</code>, <code>--kesson-font-size-ui-sm</code>, <code>--kesson-font-size-ui-arrow</code></small>
+              <strong style="font-size: var(--ds-font-size-ui-xs); letter-spacing: var(--ds-letter-ui-wide);">scroll / ui-xs</strong>
+              <div style="font-size: var(--ds-font-size-ui-sm); letter-spacing: var(--ds-letter-ui-normal);">support text / ui-sm</div>
+              <div style="font-size: var(--ds-font-size-ui-arrow);">▾ ▴ ↺</div>
+              <small><code>--ds-font-size-ui-xs</code>, <code>--ds-font-size-ui-sm</code>, <code>--ds-font-size-ui-arrow</code></small>
             </div>
           </div>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-font-serif-display,--kesson-font-serif-ui,--kesson-font-mono-ui,--kesson-font-size-ui-xs,--kesson-font-size-ui-sm,--kesson-font-size-ui-arrow,--kesson-letter-ui-tight,--kesson-letter-ui-normal,--kesson-letter-ui-wide,--kesson-letter-ui-heading,--kesson-section-heading,--kesson-card-title,--kesson-card-text,--kesson-card-summary,--kesson-overlay-tagline,--kesson-overlay-tagline-en,--kesson-control-guide,--kesson-footer-line,--kesson-surface-btn">
+          <table class="ds-variable-table" data-variable-table="--ds-font-serif-display,--ds-font-serif-ui,--ds-font-mono-ui,--ds-font-size-ui-xs,--ds-font-size-ui-sm,--ds-font-size-ui-arrow,--ds-letter-ui-tight,--ds-letter-ui-normal,--ds-letter-ui-wide,--ds-letter-ui-heading,--ds-section-heading,--ds-card-title,--ds-card-text,--ds-card-summary,--ds-overlay-tagline,--ds-overlay-tagline-en,--ds-control-guide,--ds-footer-line,--ds-surface-btn">
             <tbody></tbody>
           </table>
         </div>
@@ -919,9 +919,9 @@
       </header>
 
       <!-- Component: kesson-topbar -->
-      <!-- Variables: --kesson-topbar-main-title-size, --kesson-topbar-link-size, --kesson-topbar-bg-start, --kesson-topbar-bg-end, --kesson-topbar-border-color, --kesson-topbar-title-color, --kesson-topbar-link-color, --kesson-topbar-link-hover-color, --kesson-topbar-link-hover-bg, --kesson-topbar-note-color, --kesson-topbar-lang-color, --kesson-topbar-lang-border, --kesson-topbar-lang-bg, --kesson-topbar-nav-bg, --kesson-topbar-nav-border, --kesson-topbar-height, --kesson-topbar-blur, --kesson-topbar-saturate -->
+      <!-- Variables: --cs-topbar-main-title-size, --cs-topbar-link-size, --cs-topbar-bg-start, --cs-topbar-bg-end, --cs-topbar-border-color, --cs-topbar-title-color, --cs-topbar-link-color, --cs-topbar-link-hover-color, --cs-topbar-link-hover-bg, --cs-topbar-note-color, --cs-topbar-lang-color, --cs-topbar-lang-border, --cs-topbar-lang-bg, --cs-topbar-nav-bg, --cs-topbar-nav-border, --cs-topbar-height, --cs-topbar-blur, --cs-topbar-saturate -->
       <!-- Intent: サイトの第一印象と操作導線を担う。微調整時は色、blur、文字サイズをセットで見る -->
-      <article class="ds-component" data-component="kesson-topbar" data-source="src/styles/shell.css src/styles/topbar.css index.html" data-variables="--kesson-topbar-main-title-size,--kesson-topbar-link-size,--kesson-topbar-bg-start,--kesson-topbar-bg-end,--kesson-topbar-border-color,--kesson-topbar-title-color,--kesson-topbar-link-color,--kesson-topbar-link-hover-color,--kesson-topbar-link-hover-bg,--kesson-topbar-note-color,--kesson-topbar-lang-color,--kesson-topbar-lang-border,--kesson-topbar-lang-bg,--kesson-topbar-nav-bg,--kesson-topbar-nav-border,--kesson-topbar-height,--kesson-topbar-blur,--kesson-topbar-saturate">
+      <article class="ds-component" data-component="kesson-topbar" data-source="src/styles/shell.css src/styles/topbar.css index.html" data-variables="--cs-topbar-main-title-size,--cs-topbar-link-size,--cs-topbar-bg-start,--cs-topbar-bg-end,--cs-topbar-border-color,--cs-topbar-title-color,--cs-topbar-link-color,--cs-topbar-link-hover-color,--cs-topbar-link-hover-bg,--cs-topbar-note-color,--cs-topbar-lang-color,--cs-topbar-lang-border,--cs-topbar-lang-bg,--cs-topbar-nav-bg,--cs-topbar-nav-border,--cs-topbar-height,--cs-topbar-blur,--cs-topbar-saturate">
         <h3>Topbar</h3>
         <p>index.html の topbar を縮小して再現しています。ナビゲーションの見え方とコラボ注記の強さをここで確認します。</p>
         <div class="ds-demo-shell">
@@ -944,16 +944,16 @@
           </header>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-topbar-main-title-size,--kesson-topbar-main-title-size-sm,--kesson-topbar-link-size,--kesson-topbar-note-size,--kesson-topbar-credit-size,--kesson-topbar-bg-start,--kesson-topbar-bg-end,--kesson-topbar-border-color,--kesson-topbar-title-color,--kesson-topbar-title-hover-color,--kesson-topbar-link-color,--kesson-topbar-link-hover-color,--kesson-topbar-link-hover-bg,--kesson-topbar-note-color,--kesson-topbar-lang-color,--kesson-topbar-lang-border,--kesson-topbar-lang-bg,--kesson-topbar-nav-bg,--kesson-topbar-nav-border,--kesson-topbar-height,--kesson-topbar-alpha-strong,--kesson-topbar-alpha-soft,--kesson-topbar-border-alpha,--kesson-topbar-shadow-alpha,--kesson-topbar-blur,--kesson-topbar-saturate">
+          <table class="ds-variable-table" data-variable-table="--cs-topbar-main-title-size,--cs-topbar-main-title-size-sm,--cs-topbar-link-size,--cs-topbar-note-size,--cs-topbar-credit-size,--cs-topbar-bg-start,--cs-topbar-bg-end,--cs-topbar-border-color,--cs-topbar-title-color,--cs-topbar-title-hover-color,--cs-topbar-link-color,--cs-topbar-link-hover-color,--cs-topbar-link-hover-bg,--cs-topbar-note-color,--cs-topbar-lang-color,--cs-topbar-lang-border,--cs-topbar-lang-bg,--cs-topbar-nav-bg,--cs-topbar-nav-border,--cs-topbar-height,--cs-topbar-alpha-strong,--cs-topbar-alpha-soft,--cs-topbar-border-alpha,--cs-topbar-shadow-alpha,--cs-topbar-blur,--cs-topbar-saturate">
             <tbody></tbody>
           </table>
         </div>
       </article>
 
       <!-- Component: runtime-ui-hints -->
-      <!-- Variables: --kesson-ui-label-color, --kesson-ui-arrow-color, --kesson-ui-label-hover-color, --kesson-focus-ring-soft, --kesson-font-size-ui-xs, --kesson-font-size-ui-arrow, --kesson-control-guide, --kesson-dev-toggle-bg, --kesson-dev-toggle-bg-hover, --kesson-dev-toggle-border -->
+      <!-- Variables: --ds-ui-label-color, --ds-ui-arrow-color, --ds-ui-label-hover-color, --ds-focus-ring-soft, --ds-font-size-ui-xs, --ds-font-size-ui-arrow, --ds-control-guide, --cs-dev-toggle-bg, --cs-dev-toggle-bg-hover, --cs-dev-toggle-border -->
       <!-- Intent: ヒントや開発トグルなどの補助 UI が前景を邪魔しない強さを確認する -->
-      <article class="ds-component" data-component="runtime-ui-hints" data-source="src/styles/shell.css src/styles/dev-panel.css src/styles/dev-hud.css" data-variables="--kesson-ui-label-color,--kesson-ui-arrow-color,--kesson-ui-label-hover-color,--kesson-focus-ring-soft,--kesson-font-size-ui-xs,--kesson-font-size-ui-arrow,--kesson-control-guide,--kesson-dev-toggle-bg,--kesson-dev-toggle-bg-hover,--kesson-dev-toggle-border">
+      <article class="ds-component" data-component="runtime-ui-hints" data-source="src/styles/shell.css src/styles/dev-panel.css src/styles/dev-hud.css" data-variables="--ds-ui-label-color,--ds-ui-arrow-color,--ds-ui-label-hover-color,--ds-focus-ring-soft,--ds-font-size-ui-xs,--ds-font-size-ui-arrow,--ds-control-guide,--cs-dev-toggle-bg,--cs-dev-toggle-bg-hover,--cs-dev-toggle-border">
         <h3>Hints, Labels, Toggle</h3>
         <p>scroll hint、left link、control guide、開発トグルの色と存在感をまとめて見ます。</p>
         <div class="ds-demo-shell ds-runtime-surface">
@@ -998,7 +998,7 @@
           </div>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-ui-label-color,--kesson-ui-arrow-color,--kesson-ui-label-hover-color,--kesson-focus-ring,--kesson-focus-ring-soft,--kesson-font-size-ui-xs,--kesson-font-size-ui-arrow,--kesson-control-guide,--kesson-dev-toggle-bg,--kesson-dev-toggle-bg-hover,--kesson-dev-toggle-border,--kesson-dev-toggle-text,--kesson-dev-toggle-text-hover">
+          <table class="ds-variable-table" data-variable-table="--ds-ui-label-color,--ds-ui-arrow-color,--ds-ui-label-hover-color,--ds-focus-ring,--ds-focus-ring-soft,--ds-font-size-ui-xs,--ds-font-size-ui-arrow,--ds-control-guide,--cs-dev-toggle-bg,--cs-dev-toggle-bg-hover,--cs-dev-toggle-border,--cs-dev-toggle-text,--cs-dev-toggle-text-hover">
             <tbody></tbody>
           </table>
         </div>
@@ -1012,11 +1012,11 @@
       </header>
 
       <!-- Component: action-buttons -->
-      <!-- Variables: --kesson-action-bg, --kesson-action-border, --kesson-action-text, --kesson-action-bg-hover, --kesson-action-text-hover, --kesson-focus-ring-soft -->
+      <!-- Variables: --cs-action-bg, --cs-action-border, --cs-action-text, --cs-action-bg-hover, --cs-action-text-hover, --ds-focus-ring-soft -->
       <!-- Intent: 低コントラスト寄りの行動導線。目立たせ過ぎず、hover 時だけ情報量を増やす -->
-      <article class="ds-component" data-component="action-buttons" data-source="src/styles/shell.css src/styles/articles.css src/styles/reports.css" data-variables="--kesson-action-bg,--kesson-action-border,--kesson-action-text,--kesson-action-bg-hover,--kesson-action-text-hover,--kesson-focus-ring-soft">
+      <article class="ds-component" data-component="action-buttons" data-source="src/styles/shell.css src/styles/articles.css src/styles/reports.css" data-variables="--cs-action-bg,--cs-action-border,--cs-action-text,--cs-action-bg-hover,--cs-action-text-hover,--ds-focus-ring-soft">
         <h3>Action Surface</h3>
-        <p><code>--kesson-action-*</code> は canonical token として定義されています。Bootstrap <code>.btn</code> を土台にし、色とコントラストだけを token で上書きします。</p>
+        <p><code>--cs-action-*</code> は canonical token として定義されています。Bootstrap <code>.btn</code> を土台にし、色とコントラストだけを token で上書きします。</p>
         <div class="ds-demo-shell">
           <div class="d-flex flex-wrap gap-2" role="group" aria-label="Action button examples">
             <button type="button" class="btn ds-action-button">Primary intent</button>
@@ -1026,7 +1026,7 @@
           </div>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-action-bg,--kesson-action-border,--kesson-action-text,--kesson-action-bg-hover,--kesson-action-text-hover,--kesson-focus-ring-soft" data-scope=":root">
+          <table class="ds-variable-table" data-variable-table="--cs-action-bg,--cs-action-border,--cs-action-text,--cs-action-bg-hover,--cs-action-text-hover,--ds-focus-ring-soft" data-scope=":root">
             <tbody></tbody>
           </table>
         </div>
@@ -1036,13 +1036,13 @@
     <section class="ds-section" data-category="cards" aria-labelledby="cards-title">
       <header>
         <h2 id="cards-title">Cards and Surfaces</h2>
-        <p>カード群、placeholder、metric panel をまとめています。カードの浮遊感は <code>--kesson-card-bg</code> と shadow token の組み合わせで決まります。</p>
+        <p>カード群、placeholder、metric panel をまとめています。カードの浮遊感は <code>--cs-card-bg</code> と shadow token の組み合わせで決まります。</p>
       </header>
 
       <!-- Component: kesson-card -->
-      <!-- Variables: --kesson-card-bg, --kesson-card-border, --kesson-card-border-strong, --kesson-card-shadow-soft, --kesson-card-shadow-rich, --kesson-card-title, --kesson-card-text -->
+      <!-- Variables: --cs-card-bg, --ds-card-border, --ds-card-border-strong, --ds-card-shadow-soft, --ds-card-shadow-rich, --ds-card-title, --ds-card-text -->
       <!-- Intent: コンテンツを視覚的にグループ化。ダークテーマ上で軽い浮遊感を出す -->
-      <article class="ds-component" data-component="kesson-card" data-source="src/styles/shell.css src/articles-view.js src/reports/render.js" data-variables="--kesson-card-bg,--kesson-card-border,--kesson-card-border-strong,--kesson-card-shadow-soft,--kesson-card-shadow-rich,--kesson-card-title,--kesson-card-text">
+      <article class="ds-component" data-component="kesson-card" data-source="src/styles/shell.css src/articles-view.js src/reports/render.js" data-variables="--cs-card-bg,--ds-card-border,--ds-card-border-strong,--ds-card-shadow-soft,--ds-card-shadow-rich,--ds-card-title,--ds-card-text">
         <h3>Card Family</h3>
         <p>articles / reports 共通の土台です。border を上げると輪郭が立ち、shadow を上げると浮遊感が増します。</p>
         <div class="ds-demo-shell">
@@ -1067,7 +1067,7 @@
           </div>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-card-bg,--kesson-card-border,--kesson-card-border-strong,--kesson-card-shadow-soft,--kesson-card-shadow-rich,--kesson-card-title,--kesson-card-text,--kesson-card-summary">
+          <table class="ds-variable-table" data-variable-table="--cs-card-bg,--ds-card-border,--ds-card-border-strong,--ds-card-shadow-soft,--ds-card-shadow-rich,--ds-card-title,--ds-card-text,--ds-card-summary">
             <tbody></tbody>
           </table>
         </div>
@@ -1081,29 +1081,29 @@
       </header>
 
       <!-- Component: offcanvas-kesson -->
-      <!-- Variables: --kesson-offcanvas-width, --kesson-offcanvas-bg, --kesson-offcanvas-text, --kesson-offcanvas-heading, --kesson-offcanvas-link, --bs-offcanvas-width -->
+      <!-- Variables: --cs-offcanvas-width, --cs-offcanvas-bg, --cs-offcanvas-text, --cs-offcanvas-heading, --cs-offcanvas-link, --bs-offcanvas-width -->
       <!-- Intent: 外周情報や記事一覧を本体から分離して載せる。背景は暗く、文字とリンクだけを少し温かくする -->
-      <article class="ds-component" data-component="offcanvas-kesson" data-source="src/styles/shell.css src/styles/viewer.css src/styles/dev-hud.css index.html" data-variables="--kesson-offcanvas-width,--kesson-offcanvas-bg,--kesson-offcanvas-text,--kesson-offcanvas-heading,--kesson-offcanvas-link,--bs-offcanvas-width">
+      <article class="ds-component" data-component="offcanvas-kesson" data-source="src/styles/shell.css src/styles/viewer.css src/styles/dev-hud.css index.html" data-variables="--cs-offcanvas-width,--cs-offcanvas-bg,--cs-offcanvas-text,--cs-offcanvas-heading,--cs-offcanvas-link,--bs-offcanvas-width">
         <h3>Offcanvas Panel</h3>
         <p><code>offcanvas-kesson</code> は width と background を token で制御しています。本文文字色とリンク色は今後 token 利用を増やせる余地があります。</p>
         <div class="ds-demo-shell">
-          <aside class="offcanvas offcanvas-kesson ds-offcanvas-demo" style="--bs-offcanvas-width: var(--kesson-offcanvas-width);">
-            <h4 class="offcanvas-title-spaced" style="color: var(--kesson-offcanvas-heading);">ARTICLES</h4>
-            <p style="color: var(--kesson-offcanvas-text);">補助導線用パネル。メイン画面の没入感を壊さずに一覧や補足を出します。</p>
+          <aside class="offcanvas offcanvas-kesson ds-offcanvas-demo" style="--bs-offcanvas-width: var(--cs-offcanvas-width);">
+            <h4 class="offcanvas-title-spaced" style="color: var(--cs-offcanvas-heading);">ARTICLES</h4>
+            <p style="color: var(--cs-offcanvas-text);">補助導線用パネル。メイン画面の没入感を壊さずに一覧や補足を出します。</p>
             <p><a href="#markdown-title">Markdown sample</a></p>
           </aside>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-offcanvas-width,--kesson-offcanvas-bg,--kesson-offcanvas-text,--kesson-offcanvas-heading,--kesson-offcanvas-link,--bs-offcanvas-width" data-scope=".offcanvas-kesson">
+          <table class="ds-variable-table" data-variable-table="--cs-offcanvas-width,--cs-offcanvas-bg,--cs-offcanvas-text,--cs-offcanvas-heading,--cs-offcanvas-link,--bs-offcanvas-width" data-scope=".offcanvas-kesson">
             <tbody></tbody>
           </table>
         </div>
       </article>
 
       <!-- Component: viewer-glass -->
-      <!-- Variables: --kesson-viewer-overlay-closed, --kesson-viewer-overlay-open, --kesson-viewer-glass-bg, --kesson-viewer-glass-border, --kesson-scrollbar-thumb -->
+      <!-- Variables: --cs-viewer-overlay-closed, --cs-viewer-overlay-open, --cs-viewer-glass-bg, --cs-viewer-glass-border, --cs-scrollbar-thumb -->
       <!-- Intent: 外界を少し残したまま内容にフォーカスする。ガラス感は背景、border、shadow の組み合わせで成立する -->
-      <article class="ds-component" data-component="viewer-glass" data-source="src/styles/shell.css src/styles/viewer.css src/viewer.js" data-variables="--kesson-viewer-overlay-closed,--kesson-viewer-overlay-open,--kesson-viewer-glass-bg,--kesson-viewer-glass-border,--kesson-scrollbar-thumb">
+      <article class="ds-component" data-component="viewer-glass" data-source="src/styles/shell.css src/styles/viewer.css src/viewer.js" data-variables="--cs-viewer-overlay-closed,--cs-viewer-overlay-open,--cs-viewer-glass-bg,--cs-viewer-glass-border,--cs-scrollbar-thumb">
         <h3>Viewer Glass</h3>
         <p>Markdown や外部埋め込みの viewer 面です。スクロールバーも含めて確認できます。</p>
         <div class="ds-demo-shell ds-viewer-host">
@@ -1123,7 +1123,7 @@
           </div>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-viewer-overlay-closed,--kesson-viewer-overlay-open,--kesson-viewer-glass-bg,--kesson-viewer-glass-border,--kesson-viewer-glass-shadow,--kesson-viewer-x-handle,--kesson-scrollbar-thumb">
+          <table class="ds-variable-table" data-variable-table="--cs-viewer-overlay-closed,--cs-viewer-overlay-open,--cs-viewer-glass-bg,--cs-viewer-glass-border,--cs-viewer-glass-shadow,--cs-viewer-x-handle,--cs-scrollbar-thumb">
             <tbody></tbody>
           </table>
         </div>
@@ -1137,9 +1137,9 @@
       </header>
 
       <!-- Component: md-viewer-elements -->
-      <!-- Variables: --kesson-md-provenance, --kesson-md-h1, --kesson-md-h1-strong, --kesson-md-h2, --kesson-md-h3, --kesson-md-h4, --kesson-md-link, --kesson-md-link-hover, --kesson-md-quote, --kesson-md-inline-code, --kesson-md-inline-code-bg, --kesson-md-table-head-bg, --kesson-md-table-head-text, --kesson-md-table-cell-text -->
+      <!-- Variables: --cs-md-provenance, --cs-md-h1, --cs-md-h1-strong, --cs-md-h2, --cs-md-h3, --cs-md-h4, --cs-md-link, --cs-md-link-hover, --cs-md-quote, --cs-md-inline-code, --cs-md-inline-code-bg, --cs-md-table-head-bg, --cs-md-table-head-text, --cs-md-table-cell-text -->
       <!-- Intent: Markdown 本文の読みやすさと hierarchy を確認する -->
-      <article class="ds-component" data-component="md-viewer-elements" data-source="src/styles/shell.css src/styles/viewer.css src/reports/modal.js" data-variables="--kesson-md-provenance,--kesson-md-h1,--kesson-md-h1-strong,--kesson-md-h2,--kesson-md-h3,--kesson-md-h4,--kesson-md-link,--kesson-md-link-hover,--kesson-md-quote,--kesson-md-inline-code,--kesson-md-inline-code-bg,--kesson-md-table-head-bg,--kesson-md-table-head-text,--kesson-md-table-cell-text">
+      <article class="ds-component" data-component="md-viewer-elements" data-source="src/styles/shell.css src/styles/viewer.css src/reports/modal.js" data-variables="--cs-md-provenance,--cs-md-h1,--cs-md-h1-strong,--cs-md-h2,--cs-md-h3,--cs-md-h4,--cs-md-link,--cs-md-link-hover,--cs-md-quote,--cs-md-inline-code,--cs-md-inline-code-bg,--cs-md-table-head-bg,--cs-md-table-head-text,--cs-md-table-cell-text">
         <h3>Markdown Body</h3>
         <p>viewer.css 側は一部が値直書きなので、ここで見た値と shell token を照合しながら調整する前提です。</p>
         <div class="ds-demo-shell">
@@ -1147,7 +1147,7 @@
             <div class="md-provenance">docs / provenance / 2026-03-15</div>
             <div class="md-body">
               <h1>Design System Overview</h1>
-              <p>この本文は <a href="#cards-title">カード</a> や <a href="#reports-title">reports</a> と同じ root palette を共有します。inline code は <code>var(--kesson-md-inline-code)</code> を想定しています。</p>
+              <p>この本文は <a href="#cards-title">カード</a> や <a href="#reports-title">reports</a> と同じ root palette を共有します。inline code は <code>var(--cs-md-inline-code)</code> を想定しています。</p>
               <h2>Hierarchy</h2>
               <h3>Subsection</h3>
               <h4>Minor heading</h4>
@@ -1163,11 +1163,11 @@
                 <tbody>
                   <tr>
                     <td>Link</td>
-                    <td><code>--kesson-md-link</code></td>
+                    <td><code>--cs-md-link</code></td>
                   </tr>
                   <tr>
                     <td>Quote</td>
-                    <td><code>--kesson-md-quote</code></td>
+                    <td><code>--cs-md-quote</code></td>
                   </tr>
                 </tbody>
               </table>
@@ -1175,7 +1175,7 @@
           </article>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-md-provenance,--kesson-md-h1,--kesson-md-h1-strong,--kesson-md-h2,--kesson-md-h3,--kesson-md-h4,--kesson-md-link,--kesson-md-link-hover,--kesson-md-quote,--kesson-md-inline-code,--kesson-md-inline-code-bg,--kesson-md-table-head-bg,--kesson-md-table-head-text,--kesson-md-table-cell-text,--kesson-md-strong,--kesson-md-em,--kesson-md-pre-bg,--kesson-md-pdf-link,--kesson-md-pdf-link-hover,--kesson-md-pdf-link-hover-bg">
+          <table class="ds-variable-table" data-variable-table="--cs-md-provenance,--cs-md-h1,--cs-md-h1-strong,--cs-md-h2,--cs-md-h3,--cs-md-h4,--cs-md-link,--cs-md-link-hover,--cs-md-quote,--cs-md-inline-code,--cs-md-inline-code-bg,--cs-md-table-head-bg,--cs-md-table-head-text,--cs-md-table-cell-text,--cs-md-strong,--cs-md-em,--cs-md-pre-bg,--cs-md-pdf-link,--cs-md-pdf-link-hover,--cs-md-pdf-link-hover-bg">
             <tbody></tbody>
           </table>
         </div>
@@ -1189,9 +1189,9 @@
       </header>
 
       <!-- Component: form-controls -->
-      <!-- Variables: --kesson-focus-ring, --kesson-focus-ring-soft, --kesson-dev-toggle-bg, --kesson-dev-toggle-bg-hover, --kesson-dev-toggle-border -->
+      <!-- Variables: --ds-focus-ring, --ds-focus-ring-soft, --cs-dev-toggle-bg, --cs-dev-toggle-bg-hover, --cs-dev-toggle-border -->
       <!-- Intent: 設定変更や開発用調整を行う面。視認性は要るが主役にはしない -->
-      <article class="ds-component" data-component="form-controls" data-source="src/styles/dev-panel.css src/styles/dev-hud.css src/dev-panel.js" data-variables="--kesson-focus-ring,--kesson-focus-ring-soft,--kesson-dev-toggle-bg,--kesson-dev-toggle-bg-hover,--kesson-dev-toggle-border">
+      <article class="ds-component" data-component="form-controls" data-source="src/styles/dev-panel.css src/styles/dev-hud.css src/dev-panel.js" data-variables="--ds-focus-ring,--ds-focus-ring-soft,--cs-dev-toggle-bg,--cs-dev-toggle-bg-hover,--cs-dev-toggle-border">
         <h3>Dev Panel Form Controls</h3>
         <p>dev-panel.css の input / label / range を縮小展示しています。トグルは runtime chrome と同じ token を共有します。</p>
         <div class="ds-demo-shell ds-dev-panel-demo">
@@ -1225,23 +1225,23 @@
           </aside>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-focus-ring,--kesson-focus-ring-soft,--kesson-dev-toggle-bg,--kesson-dev-toggle-bg-hover,--kesson-dev-toggle-border,--kesson-dev-toggle-text,--kesson-dev-toggle-text-hover,--kesson-dev-panel-bg,--kesson-dev-panel-border,--kesson-dev-panel-header-border,--kesson-dev-panel-title-color,--kesson-dev-panel-accordion-bg,--kesson-dev-panel-accordion-text,--kesson-dev-panel-accordion-active-bg,--kesson-dev-panel-body-bg,--kesson-dev-panel-label-color,--kesson-dev-panel-value-color,--kesson-dev-hud-border,--kesson-dev-hud-bg,--kesson-dev-hud-text">
+          <table class="ds-variable-table" data-variable-table="--ds-focus-ring,--ds-focus-ring-soft,--cs-dev-toggle-bg,--cs-dev-toggle-bg-hover,--cs-dev-toggle-border,--cs-dev-toggle-text,--cs-dev-toggle-text-hover,--cs-dev-panel-bg,--cs-dev-panel-border,--cs-dev-panel-header-border,--cs-dev-panel-title-color,--cs-dev-panel-accordion-bg,--cs-dev-panel-accordion-text,--cs-dev-panel-accordion-active-bg,--cs-dev-panel-body-bg,--cs-dev-panel-label-color,--cs-dev-panel-value-color,--cs-dev-hud-border,--cs-dev-hud-bg,--cs-dev-hud-text">
             <tbody></tbody>
           </table>
         </div>
       </article>
 
       <!-- Component: error-state -->
-      <!-- Variables: --kesson-error-color, --kesson-error-size -->
+      <!-- Variables: --ds-error-color, --ds-error-size -->
       <!-- Intent: 読み込み失敗や空状態の異常を静かに伝える。派手すぎず見逃さない赤にする -->
-      <article class="ds-component" data-component="error-state" data-source="src/styles/shell.css src/styles/articles.css" data-variables="--kesson-error-color,--kesson-error-size">
+      <article class="ds-component" data-component="error-state" data-source="src/styles/shell.css src/styles/articles.css" data-variables="--ds-error-color,--ds-error-size">
         <h3>Error State</h3>
         <p>articles の読み込み失敗表示に相当します。</p>
         <div class="ds-demo-shell">
           <p id="articles-error" class="ds-error">記事データを読み込めませんでした。ネットワークと JSON を確認してください。</p>
         </div>
         <div class="ds-table-wrap">
-          <table class="ds-variable-table" data-variable-table="--kesson-error-color,--kesson-error-size">
+          <table class="ds-variable-table" data-variable-table="--ds-error-color,--ds-error-size">
             <tbody></tbody>
           </table>
         </div>
@@ -1333,30 +1333,30 @@
       </header>
 
       <!-- Component: font-size-ctrl -->
-      <!-- Variables: --kesson-font-size-ui-xs, --kesson-font-size-ui-sm, --kesson-section-heading, --kesson-card-title, --kesson-card-text, --kesson-overlay-tagline, --kesson-footer-line, --kesson-dev-hud-font-size, --kesson-topbar-link-size, --kesson-topbar-main-title-size, --kesson-h1-size, --reports-font-step -->
+      <!-- Variables: --ds-font-size-ui-xs, --ds-font-size-ui-sm, --ds-section-heading, --ds-card-title, --ds-card-text, --ds-overlay-tagline, --ds-footer-line, --cs-dev-hud-font-size, --cs-topbar-link-size, --cs-topbar-main-title-size, --ds-h1-size, --reports-font-step -->
       <!-- Intent: A+/A- ボタンの動作確認と、step 変化時のフォントサイズ連動を視覚的にデモする -->
-      <article class="ds-component" data-component="font-size-ctrl" data-source="src/font-size-ctrl.js" data-variables="--kesson-font-size-ui-xs,--kesson-font-size-ui-sm,--kesson-section-heading,--kesson-card-title,--kesson-card-text,--kesson-overlay-tagline,--kesson-footer-line,--kesson-dev-hud-font-size,--kesson-topbar-link-size,--kesson-topbar-main-title-size,--kesson-h1-size,--reports-font-step">
+      <article class="ds-component" data-component="font-size-ctrl" data-source="src/font-size-ctrl.js" data-variables="--ds-font-size-ui-xs,--ds-font-size-ui-sm,--ds-section-heading,--ds-card-title,--ds-card-text,--ds-overlay-tagline,--ds-footer-line,--cs-dev-hud-font-size,--cs-topbar-link-size,--cs-topbar-main-title-size,--ds-h1-size,--reports-font-step">
         <h3>Controls</h3>
         <p>ボタンを押すとページ全体のフォントサイズが変わります。step 範囲: -1 ~ 7 (default: 0)</p>
         <div class="ds-demo-shell">
           <div style="display: flex; align-items: center; gap: 0.6rem;">
-            <button type="button" id="font-size-down" style="padding: 0.3rem 0.7rem; border: 1px solid var(--kesson-topbar-nav-border); border-radius: 4px; background: transparent; color: var(--kesson-topbar-link-color); font-family: var(--kesson-font-mono-ui); font-size: var(--kesson-topbar-credit-size, 0.80rem); cursor: pointer;">A-</button>
-            <button type="button" id="font-size-reset" style="padding: 0.3rem 0.7rem; border: 1px solid var(--kesson-topbar-nav-border); border-radius: 4px; background: transparent; color: var(--kesson-topbar-link-color); font-family: var(--kesson-font-mono-ui); font-size: var(--kesson-topbar-credit-size, 0.80rem); cursor: pointer;">Reset</button>
-            <button type="button" id="font-size-up" style="padding: 0.3rem 0.7rem; border: 1px solid var(--kesson-topbar-nav-border); border-radius: 4px; background: transparent; color: var(--kesson-topbar-link-color); font-family: var(--kesson-font-mono-ui); font-size: var(--kesson-topbar-credit-size, 0.80rem); cursor: pointer;">A+</button>
-            <span id="ds-font-step-readout" style="font-family: var(--kesson-font-mono-ui); font-size: var(--kesson-dev-hud-font-size, 0.80rem); color: var(--kesson-dev-hud-text);">step: 0</span>
+            <button type="button" id="font-size-down" style="padding: 0.3rem 0.7rem; border: 1px solid var(--cs-topbar-nav-border); border-radius: 4px; background: transparent; color: var(--cs-topbar-link-color); font-family: var(--ds-font-mono-ui); font-size: var(--cs-topbar-credit-size, 0.80rem); cursor: pointer;">A-</button>
+            <button type="button" id="font-size-reset" style="padding: 0.3rem 0.7rem; border: 1px solid var(--cs-topbar-nav-border); border-radius: 4px; background: transparent; color: var(--cs-topbar-link-color); font-family: var(--ds-font-mono-ui); font-size: var(--cs-topbar-credit-size, 0.80rem); cursor: pointer;">Reset</button>
+            <button type="button" id="font-size-up" style="padding: 0.3rem 0.7rem; border: 1px solid var(--cs-topbar-nav-border); border-radius: 4px; background: transparent; color: var(--cs-topbar-link-color); font-family: var(--ds-font-mono-ui); font-size: var(--cs-topbar-credit-size, 0.80rem); cursor: pointer;">A+</button>
+            <span id="ds-font-step-readout" style="font-family: var(--ds-font-mono-ui); font-size: var(--cs-dev-hud-font-size, 0.80rem); color: var(--cs-dev-hud-text);">step: 0</span>
           </div>
         </div>
 
         <h3>Sample Text at Various Variables</h3>
         <div class="ds-demo-shell">
           <div style="display: grid; gap: 0.7rem;">
-            <p style="margin:0; font-size: var(--kesson-section-heading, 0.80rem); font-family: var(--kesson-font-mono-ui); letter-spacing: 0.15em; text-transform: uppercase; color: rgba(var(--color-sub-text), 0.5);">section-heading: SAMPLE HEADING</p>
-            <p style="margin:0; font-size: var(--kesson-card-title, 0.80rem); color: #fff;">card-title: Sample Card Title</p>
-            <p style="margin:0; font-size: var(--kesson-card-text, 0.80rem); color: rgba(var(--color-heading), 0.5);">card-text: Sample card description text</p>
-            <p style="margin:0; font-size: var(--kesson-overlay-tagline, 0.80rem); font-family: var(--kesson-font-serif-display); color: rgba(var(--color-heading), 0.75);">overlay-tagline: Sample tagline</p>
-            <p style="margin:0; font-size: var(--kesson-footer-line, 0.80rem); font-family: var(--kesson-font-mono-ui); color: rgba(150, 175, 210, 0.25);">footer-line: &lt;footer sample text /&gt;</p>
-            <p style="margin:0; font-size: var(--kesson-topbar-main-title-size); font-family: var(--kesson-font-serif-display); color: var(--kesson-topbar-title-color);">topbar-main-title: creation-space</p>
-            <p style="margin:0; font-size: var(--kesson-h1-size); font-family: var(--kesson-font-serif-display); color: rgba(var(--color-heading), 0.95);">h1-size: Hero Heading</p>
+            <p style="margin:0; font-size: var(--ds-section-heading, 0.80rem); font-family: var(--ds-font-mono-ui); letter-spacing: 0.15em; text-transform: uppercase; color: rgba(var(--color-sub-text), 0.5);">section-heading: SAMPLE HEADING</p>
+            <p style="margin:0; font-size: var(--ds-card-title, 0.80rem); color: #fff;">card-title: Sample Card Title</p>
+            <p style="margin:0; font-size: var(--ds-card-text, 0.80rem); color: rgba(var(--color-heading), 0.5);">card-text: Sample card description text</p>
+            <p style="margin:0; font-size: var(--ds-overlay-tagline, 0.80rem); font-family: var(--ds-font-serif-display); color: rgba(var(--color-heading), 0.75);">overlay-tagline: Sample tagline</p>
+            <p style="margin:0; font-size: var(--ds-footer-line, 0.80rem); font-family: var(--ds-font-mono-ui); color: rgba(150, 175, 210, 0.25);">footer-line: &lt;footer sample text /&gt;</p>
+            <p style="margin:0; font-size: var(--cs-topbar-main-title-size); font-family: var(--ds-font-serif-display); color: var(--cs-topbar-title-color);">topbar-main-title: creation-space</p>
+            <p style="margin:0; font-size: var(--ds-h1-size); font-family: var(--ds-font-serif-display); color: rgba(var(--color-heading), 0.95);">h1-size: Hero Heading</p>
           </div>
         </div>
       </article>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -26,7 +26,7 @@
 
 ## 変更時に守るべき制約
 
-- 変数名の命名規則: `--kesson-{category}-{name}` または `--color-{name}`
+- 変数名の命名規則: `--cs-{category}-{name}` または `--color-{name}`
 - `rgb()` ではなく `r, g, b` の 3 値で定義する。`rgba()` で透明度を柔軟に変えるため
 - ダークテーマ前提: 背景は暗い。テキストは明るい。コントラストを確保する
 - `shell.css` を変更したら `dev-components.html` も確認・更新する
@@ -38,13 +38,13 @@
 | prefix | 用途 |
 |---|---|
 | `--color-*` | 基本パレット（accent, sub-text, highlight, link, heading, bg-body） |
-| `--kesson-font-*` | タイポグラフィ（serif-display, serif-ui, mono-ui, mono-system） |
-| `--kesson-card-*` | カードコンポーネント |
-| `--kesson-action-*` | ボタン・アクション |
-| `--kesson-offcanvas-*` | オフキャンバスパネル |
-| `--kesson-viewer-*` | MD / 埋め込み viewer |
-| `--kesson-md-*` | MD 内の要素（h1-h4, link, quote, code, table） |
-| `--kesson-ui-*` | UI 部品（ラベル、矢印、補助表示） |
+| `--cs-font-*` | タイポグラフィ（serif-display, serif-ui, mono-ui, mono-system） |
+| `--cs-card-*` | カードコンポーネント |
+| `--cs-action-*` | ボタン・アクション |
+| `--cs-offcanvas-*` | オフキャンバスパネル |
+| `--cs-viewer-*` | MD / 埋め込み viewer |
+| `--cs-md-*` | MD 内の要素（h1-h4, link, quote, code, table） |
+| `--cs-ui-*` | UI 部品（ラベル、矢印、補助表示） |
 | `--reports-*` | Reports 専用の派生変数。root token から組み立てる二次層 |
 
 ## 判断基準

--- a/src/font-size-ctrl.js
+++ b/src/font-size-ctrl.js
@@ -10,47 +10,47 @@ const MIGRATION_KEY = 'kesson-font-step-v5';
 
 // Global UI font sizes (shell.css :root)
 const FONT_VARS = {
-    '--kesson-font-size-ui-xs': 0.85,
-    '--kesson-font-size-ui-sm': 0.88,
+    '--ds-font-size-ui-xs': 0.85,
+    '--ds-font-size-ui-sm': 0.88,
 };
 
 const CLASS_VARS = {
     // -- Card & section --
-    '--kesson-section-heading': 0.88,
-    '--kesson-card-title': 1.00,
-    '--kesson-card-text': 0.92,
-    '--kesson-card-summary': 0.92,
+    '--ds-section-heading': 0.88,
+    '--ds-card-title': 1.00,
+    '--ds-card-text': 0.92,
+    '--ds-card-summary': 0.92,
 
     // -- Overlay & guide --
-    '--kesson-overlay-tagline': 0.92,
-    '--kesson-overlay-tagline-en': 0.88,
-    '--kesson-control-guide': 0.82,
-    '--kesson-surface-btn': 0.88,
+    '--ds-overlay-tagline': 0.92,
+    '--ds-overlay-tagline-en': 0.88,
+    '--ds-control-guide': 0.82,
+    '--ds-surface-btn': 0.88,
 
     // -- Footer --
-    '--kesson-footer-line': 0.82,
-    '--kesson-footer-signature-size': 0.88,
+    '--ds-footer-line': 0.82,
+    '--ds-footer-signature-size': 0.88,
 
     // -- Dev HUD --
-    '--kesson-dev-hud-font-size': 0.80,
+    '--cs-dev-hud-font-size': 0.80,
 
     // -- Topbar --
-    '--kesson-topbar-link-size': 0.88,
-    '--kesson-topbar-credit-size': 0.84,
-    '--kesson-topbar-note-size': 0.88,
-    '--kesson-topbar-meta-size': 0.86,
-    '--kesson-topbar-meta-author-size': 0.84,
-    '--kesson-topbar-subtitle-size-md': 0.88,
-    '--kesson-topbar-title-size': 0.88,
-    '--kesson-topbar-main-title-size': 1.04,
-    '--kesson-topbar-main-title-size-sm': 0.92,
+    '--cs-topbar-link-size': 0.88,
+    '--cs-topbar-credit-size': 0.84,
+    '--cs-topbar-note-size': 0.88,
+    '--cs-topbar-meta-size': 0.86,
+    '--cs-topbar-meta-author-size': 0.84,
+    '--cs-topbar-subtitle-size-md': 0.88,
+    '--cs-topbar-title-size': 0.88,
+    '--cs-topbar-main-title-size': 1.04,
+    '--cs-topbar-main-title-size-sm': 0.92,
 
     // -- Graphic switcher --
-    '--kesson-graphic-switcher-label': 0.88,
-    '--kesson-graphic-switcher-btn': 0.88,
+    '--cs-graphic-switcher-label': 0.88,
+    '--cs-graphic-switcher-btn': 0.88,
 
     // -- Hero h1 --
-    '--kesson-h1-size': 1.10,
+    '--ds-h1-size': 1.10,
 };
 
 function normalizeStep(step) {

--- a/src/styles/about-modal.css
+++ b/src/styles/about-modal.css
@@ -36,12 +36,12 @@
 }
 
 .about-trigger:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring, rgba(100, 150, 255, 0.86));
+  outline: 2px solid var(--ds-focus-ring, rgba(100, 150, 255, 0.86));
   outline-offset: 2px;
 }
 
 .about-trigger__letter {
-  font-family: var(--kesson-font-serif-display, 'Noto Serif JP', serif);
+  font-family: var(--ds-font-serif-display, 'Noto Serif JP', serif);
   font-size: 1.2rem;
   font-style: italic;
   line-height: 1;
@@ -79,12 +79,12 @@
   max-height: 80vh;
   cursor: default;
   overflow-y: auto;
-  background: var(--kesson-viewer-glass-bg, rgba(12, 18, 30, 0.88));
+  background: var(--cs-viewer-glass-bg, rgba(12, 18, 30, 0.88));
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
   border: 1px solid rgba(100, 150, 255, 0.06);
   border-radius: 3px;
-  box-shadow: var(--kesson-viewer-glass-shadow,
+  box-shadow: var(--cs-viewer-glass-shadow,
     0 0 60px rgba(0, 0, 0, 0.4),
     0 0 120px rgba(30, 60, 120, 0.1),
     inset 0 0 60px rgba(20, 40, 80, 0.05));
@@ -125,13 +125,13 @@
 }
 
 .about-close:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring, rgba(100, 150, 255, 0.86));
+  outline: 2px solid var(--ds-focus-ring, rgba(100, 150, 255, 0.86));
   outline-offset: 2px;
 }
 
 /* ── Title ── */
 .about-title {
-  font-family: var(--kesson-font-serif-display, serif);
+  font-family: var(--ds-font-serif-display, serif);
   font-size: 1.15rem;
   color: rgba(var(--color-heading, 255, 255, 255), 0.92);
   letter-spacing: 0.08em;
@@ -141,7 +141,7 @@
 
 /* ── Body ── */
 .about-body {
-  font-family: var(--kesson-font-serif-display, serif);
+  font-family: var(--ds-font-serif-display, serif);
   font-size: 0.9rem;
   color: rgba(var(--color-highlight, 220, 230, 245), 0.82);
   line-height: 1.9;
@@ -159,7 +159,7 @@
 .about-stages {
   display: block;
   text-align: center;
-  font-family: var(--kesson-font-serif-ui, serif);
+  font-family: var(--ds-font-serif-ui, serif);
   font-size: 0.88rem;
   color: rgba(var(--color-accent, 100, 150, 255), 0.7);
   letter-spacing: 0.12em;

--- a/src/styles/articles.css
+++ b/src/styles/articles.css
@@ -26,8 +26,8 @@
 .btn-read-more {
   display: block;
   margin: 1rem auto 0;
-  font-size: var(--kesson-font-size-ui-sm, 0.80rem);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-size: var(--ds-font-size-ui-sm, 0.80rem);
+  letter-spacing: var(--ds-letter-ui-wide);
   padding: 10px 24px;
 }
 
@@ -61,7 +61,7 @@
 }
 
 #creation-cards-container {
-  margin-top: var(--kesson-section-grid-margin-top);
+  margin-top: var(--cs-section-grid-margin-top);
 }
 
 .creation-card-placeholder {
@@ -83,7 +83,7 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(224, 236, 255, 0.86);
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
 }
 
 .creation-card-placeholder p {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -4,7 +4,7 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
   background: var(--color-bg-body);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
 }
 
 #canvas-container {

--- a/src/styles/creation.css
+++ b/src/styles/creation.css
@@ -56,12 +56,12 @@ body.creation-page {
 .card.kesson-card.btn {
   color: rgba(var(--color-heading), 0.5);
   border-radius: 0.5rem;
-  box-shadow: var(--kesson-card-shadow-soft);
+  box-shadow: var(--ds-card-shadow-soft);
 }
 
 .card.kesson-card.btn:hover {
   color: rgba(var(--color-heading), 0.7);
-  box-shadow: var(--kesson-card-shadow-rich);
+  box-shadow: var(--ds-card-shadow-rich);
 }
 
 /* ── Section headings — high contrast + shadow ── */
@@ -227,7 +227,7 @@ body.creation-page {
 }
 
 .prologue-desc-title {
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   font-size: clamp(1rem, 2.5vmin, 1.15rem);
   font-weight: 400;
   letter-spacing: 0.05em;
@@ -237,7 +237,7 @@ body.creation-page {
 }
 
 .prologue-desc-text {
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   font-size: clamp(0.82rem, 2vmin, 0.95rem);
   font-weight: 300;
   color: rgba(210, 225, 250, var(--text-timeline-desc-opacity));
@@ -256,7 +256,7 @@ body.creation-page {
 }
 
 .next-question-text {
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   font-size: clamp(0.9rem, 2.5vmin, 1.1rem);
   font-weight: 300;
   color: rgba(210, 225, 250, var(--text-question-opacity));

--- a/src/styles/dev-hud.css
+++ b/src/styles/dev-hud.css
@@ -1,18 +1,18 @@
 .dev-components-link {
   display: none;
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 2.95rem);
+  top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 2.95rem);
   right: 0.95rem;
   z-index: 58;
   padding: 0.2rem 0.48rem;
   border-radius: 999px;
-  border: 1px solid var(--kesson-dev-hud-border);
-  background: var(--kesson-dev-hud-bg);
-  color: var(--kesson-dev-hud-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  border: 1px solid var(--cs-dev-hud-border);
+  background: var(--cs-dev-hud-bg);
+  color: var(--cs-dev-hud-text);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
   letter-spacing: 0.04em;
   line-height: 1;
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   white-space: nowrap;
   text-decoration: none;
   pointer-events: auto;
@@ -38,7 +38,7 @@
 
 #intent-timeline-hud {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 4.1rem);
+  top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 4.1rem);
   left: 0.95rem;
   z-index: 58;
   width: fit-content;
@@ -46,11 +46,11 @@
   max-width: min(90vw, 26rem);
   padding: 0.5rem;
   border-radius: 0.5rem;
-  border: 1px solid var(--kesson-dev-hud-border);
-  background: var(--kesson-dev-hud-bg);
-  color: var(--kesson-dev-hud-text);
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  border: 1px solid var(--cs-dev-hud-border);
+  background: var(--cs-dev-hud-bg);
+  color: var(--cs-dev-hud-text);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
   line-height: 1.45;
   display: none;
   backdrop-filter: blur(8px);
@@ -68,11 +68,11 @@
   max-width: min(90vw, 26rem);
   padding: 0.5rem;
   border-radius: 0.5rem;
-  border: 1px solid var(--kesson-dev-hud-border);
-  background: var(--kesson-dev-hud-bg);
-  color: var(--kesson-dev-hud-text);
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  border: 1px solid var(--cs-dev-hud-border);
+  background: var(--cs-dev-hud-bg);
+  color: var(--cs-dev-hud-text);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
   line-height: 1.45;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -85,7 +85,7 @@
 .intent-timeline-hud-readout {
   margin: 0;
   white-space: pre;
-  color: var(--kesson-dev-hud-text);
+  color: var(--cs-dev-hud-text);
 }
 
 .intent-timeline-hud-controls {
@@ -95,7 +95,7 @@
 }
 
 .intent-timeline-hud-controls label {
-  color: var(--kesson-dev-panel-help-color);
+  color: var(--cs-dev-panel-help-color);
   letter-spacing: 0.05em;
 }
 
@@ -103,13 +103,13 @@
 #intent-timeline-start-utime-input,
 #intent-timeline-shift-sec-input {
   width: 100%;
-  border: 1px solid var(--kesson-dev-hud-input-border);
+  border: 1px solid var(--cs-dev-hud-input-border);
   border-radius: 0.32rem;
-  background: var(--kesson-dev-hud-input-bg);
-  color: var(--kesson-dev-hud-input-text);
+  background: var(--cs-dev-hud-input-bg);
+  color: var(--cs-dev-hud-input-text);
   padding: 0.22rem 0.38rem;
   font-family: inherit;
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
   line-height: 1.2;
 }
 
@@ -124,19 +124,19 @@
 }
 
 .intent-timeline-hud-actions button {
-  border: 1px solid var(--kesson-dev-hud-btn-border);
+  border: 1px solid var(--cs-dev-hud-btn-border);
   border-radius: 0.32rem;
-  background: var(--kesson-dev-hud-btn-bg);
-  color: var(--kesson-dev-hud-btn-text);
+  background: var(--cs-dev-hud-btn-bg);
+  color: var(--cs-dev-hud-btn-text);
   padding: 0.22rem 0.32rem;
   font-family: inherit;
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
   line-height: 1.2;
   cursor: pointer;
 }
 
 .intent-timeline-hud-actions button:hover {
-  background: var(--kesson-dev-hud-btn-bg-hover);
+  background: var(--cs-dev-hud-btn-bg-hover);
 }
 
 #dev-toggle {
@@ -145,14 +145,14 @@
   right: 0;
   transform: translateY(-50%);
   z-index: 1001;
-  background: var(--kesson-dev-toggle-bg);
+  background: var(--cs-dev-toggle-bg);
   backdrop-filter: blur(8px);
-  border: 1px solid var(--kesson-dev-toggle-border);
+  border: 1px solid var(--cs-dev-toggle-border);
   border-right: none;
   border-radius: 4px 0 0 4px;
-  color: var(--kesson-dev-toggle-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
-  font-family: var(--kesson-font-mono-ui);
+  color: var(--cs-dev-toggle-text);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
+  font-family: var(--ds-font-mono-ui);
   padding: 8px 5px;
   cursor: pointer;
   writing-mode: vertical-rl;
@@ -161,8 +161,8 @@
 }
 
 #dev-toggle:hover {
-  color: var(--kesson-dev-toggle-text-hover);
-  background: var(--kesson-dev-toggle-bg-hover);
+  color: var(--cs-dev-toggle-text-hover);
+  background: var(--cs-dev-toggle-bg-hover);
 }
 
 #dev-toggle.open {
@@ -202,7 +202,7 @@
 
 #dev-panel .form-check-label {
   font-size: 0.80rem;
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   color: rgba(var(--color-sub-text), 0.7);
   order: -1;
   padding-left: 0;
@@ -233,8 +233,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
-  font-family: var(--kesson-font-mono-ui);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
+  font-family: var(--ds-font-mono-ui);
   color: rgba(var(--color-sub-text), 0.6);
   margin-bottom: 0.15rem;
 }
@@ -246,7 +246,7 @@
 }
 
 #dev-export-result {
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
   max-height: 180px;
   overflow-y: auto;
   display: none;
@@ -254,7 +254,7 @@
 }
 
 .dev-panel-header-text {
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   letter-spacing: 0.1em;
 }
 
@@ -268,14 +268,14 @@
   right: 0;
   transform: translateY(-50%);
   z-index: 1001;
-  background: var(--kesson-dev-toggle-bg);
+  background: var(--cs-dev-toggle-bg);
   backdrop-filter: blur(8px);
-  border: 1px solid var(--kesson-dev-toggle-border);
+  border: 1px solid var(--cs-dev-toggle-border);
   border-right: none;
   border-radius: 4px 0 0 4px;
-  color: var(--kesson-dev-toggle-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
-  font-family: var(--kesson-font-mono-ui);
+  color: var(--cs-dev-toggle-text);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
+  font-family: var(--ds-font-mono-ui);
   padding: 8px 5px;
   cursor: pointer;
   writing-mode: vertical-rl;
@@ -284,8 +284,8 @@
 }
 
 #dev-links-toggle:hover {
-  color: var(--kesson-dev-toggle-text-hover);
-  background: var(--kesson-dev-toggle-bg-hover);
+  color: var(--cs-dev-toggle-text-hover);
+  background: var(--cs-dev-toggle-bg-hover);
 }
 
 .offcanvas-links {
@@ -317,7 +317,7 @@
 .dev-links-key {
   font-size: 0.80rem;
   color: rgba(170, 190, 220, 0.7);
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   letter-spacing: 0.05em;
 }
 
@@ -342,7 +342,7 @@
 
 @media (max-width: 767.98px) {
   #intent-timeline-hud {
-    top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 3.8rem);
+    top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 3.8rem);
     left: 0.6rem;
     width: fit-content;
     min-width: 0;

--- a/src/styles/dev-panel.css
+++ b/src/styles/dev-panel.css
@@ -1,36 +1,36 @@
 :root {
-  --kesson-dev-toggle-bg: rgba(20, 30, 50, 0.7);
-  --kesson-dev-toggle-bg-hover: rgba(30, 45, 70, 0.82);
-  --kesson-dev-toggle-border: rgba(var(--color-accent), 0.15);
-  --kesson-dev-toggle-text: rgba(180, 200, 255, 0.75);
-  --kesson-dev-toggle-text-hover: rgba(210, 225, 255, 0.95);
-  --kesson-dev-panel-bg: rgba(7, 12, 24, 0.96);
-  --kesson-dev-panel-border: rgba(140, 178, 255, 0.3);
-  --kesson-dev-panel-header-border: rgba(140, 178, 255, 0.25);
-  --kesson-dev-panel-title-color: rgba(223, 236, 255, 0.95);
-  --kesson-dev-panel-accordion-bg: rgba(26, 40, 70, 0.5);
-  --kesson-dev-panel-accordion-text: rgba(222, 235, 255, 0.92);
-  --kesson-dev-panel-accordion-active-bg: rgba(46, 72, 116, 0.7);
-  --kesson-dev-panel-body-bg: rgba(11, 20, 38, 0.75);
-  --kesson-dev-panel-label-color: rgba(188, 211, 245, 0.95);
-  --kesson-dev-panel-help-color: rgba(176, 201, 238, 0.82);
-  --kesson-dev-panel-help-sub-color: rgba(162, 188, 228, 0.72);
-  --kesson-dev-panel-value-color: rgba(201, 221, 255, 0.86);
-  --kesson-dev-panel-status-color: rgba(201, 221, 255, 0.8);
-  --kesson-dev-panel-empty-bg: rgba(11, 20, 38, 0.6);
-  --kesson-dev-panel-empty-border: rgba(140, 178, 255, 0.25);
-  --kesson-dev-panel-empty-text: rgba(201, 221, 255, 0.85);
-  --kesson-dev-hud-border: rgba(120, 164, 235, 0.42);
-  --kesson-dev-hud-bg: rgba(8, 14, 26, 0.84);
-  --kesson-dev-hud-text: rgba(205, 224, 255, 0.92);
-  --kesson-dev-hud-btn-border: rgba(130, 170, 240, 0.45);
-  --kesson-dev-hud-btn-bg: rgba(100, 152, 246, 0.2);
-  --kesson-dev-hud-btn-text: rgba(238, 246, 255, 0.96);
-  --kesson-dev-hud-btn-bg-hover: rgba(116, 165, 244, 0.32);
-  --kesson-dev-hud-input-border: rgba(130, 170, 240, 0.35);
-  --kesson-dev-hud-input-bg: rgba(10, 18, 32, 0.88);
-  --kesson-dev-hud-input-text: rgba(220, 235, 255, 0.95);
-  --kesson-dev-hud-font-size: 0.80rem;
+  --cs-dev-toggle-bg: rgba(20, 30, 50, 0.7);
+  --cs-dev-toggle-bg-hover: rgba(30, 45, 70, 0.82);
+  --cs-dev-toggle-border: rgba(var(--color-accent), 0.15);
+  --cs-dev-toggle-text: rgba(180, 200, 255, 0.75);
+  --cs-dev-toggle-text-hover: rgba(210, 225, 255, 0.95);
+  --cs-dev-panel-bg: rgba(7, 12, 24, 0.96);
+  --cs-dev-panel-border: rgba(140, 178, 255, 0.3);
+  --cs-dev-panel-header-border: rgba(140, 178, 255, 0.25);
+  --cs-dev-panel-title-color: rgba(223, 236, 255, 0.95);
+  --cs-dev-panel-accordion-bg: rgba(26, 40, 70, 0.5);
+  --cs-dev-panel-accordion-text: rgba(222, 235, 255, 0.92);
+  --cs-dev-panel-accordion-active-bg: rgba(46, 72, 116, 0.7);
+  --cs-dev-panel-body-bg: rgba(11, 20, 38, 0.75);
+  --cs-dev-panel-label-color: rgba(188, 211, 245, 0.95);
+  --cs-dev-panel-help-color: rgba(176, 201, 238, 0.82);
+  --cs-dev-panel-help-sub-color: rgba(162, 188, 228, 0.72);
+  --cs-dev-panel-value-color: rgba(201, 221, 255, 0.86);
+  --cs-dev-panel-status-color: rgba(201, 221, 255, 0.8);
+  --cs-dev-panel-empty-bg: rgba(11, 20, 38, 0.6);
+  --cs-dev-panel-empty-border: rgba(140, 178, 255, 0.25);
+  --cs-dev-panel-empty-text: rgba(201, 221, 255, 0.85);
+  --cs-dev-hud-border: rgba(120, 164, 235, 0.42);
+  --cs-dev-hud-bg: rgba(8, 14, 26, 0.84);
+  --cs-dev-hud-text: rgba(205, 224, 255, 0.92);
+  --cs-dev-hud-btn-border: rgba(130, 170, 240, 0.45);
+  --cs-dev-hud-btn-bg: rgba(100, 152, 246, 0.2);
+  --cs-dev-hud-btn-text: rgba(238, 246, 255, 0.96);
+  --cs-dev-hud-btn-bg-hover: rgba(116, 165, 244, 0.32);
+  --cs-dev-hud-input-border: rgba(130, 170, 240, 0.35);
+  --cs-dev-hud-input-bg: rgba(10, 18, 32, 0.88);
+  --cs-dev-hud-input-text: rgba(220, 235, 255, 0.95);
+  --cs-dev-hud-font-size: 0.80rem;
 }
 
 #dev-panel-toggle {
@@ -41,14 +41,14 @@
   transform: translateY(-50%);
   /* Match LINKS toggle layering: hidden behind offcanvas/backdrop when opened. */
   z-index: 1001;
-  background: var(--kesson-dev-toggle-bg);
+  background: var(--cs-dev-toggle-bg);
   backdrop-filter: blur(8px);
-  border: 1px solid var(--kesson-dev-toggle-border);
+  border: 1px solid var(--cs-dev-toggle-border);
   border-right: none;
   border-radius: 4px 0 0 4px;
-  color: var(--kesson-dev-toggle-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
-  font-family: var(--kesson-font-mono-ui);
+  color: var(--cs-dev-toggle-text);
+  font-size: var(--cs-dev-hud-font-size, 0.80rem);
+  font-family: var(--ds-font-mono-ui);
   padding: 8px 5px;
   cursor: pointer;
   writing-mode: vertical-rl;
@@ -62,8 +62,8 @@
 }
 
 #dev-panel-toggle:hover {
-  color: var(--kesson-dev-toggle-text-hover);
-  background: var(--kesson-dev-toggle-bg-hover);
+  color: var(--cs-dev-toggle-text-hover);
+  background: var(--cs-dev-toggle-bg-hover);
 }
 
 #dev-panel {
@@ -74,8 +74,8 @@
   height: 100vh;
   z-index: 1200;
   color: #d9e5ff;
-  background: var(--kesson-dev-panel-bg);
-  border-left: 1px solid var(--kesson-dev-panel-border);
+  background: var(--cs-dev-panel-bg);
+  border-left: 1px solid var(--cs-dev-panel-border);
   transform: translateX(100%);
   transition: transform 0.25s ease;
   overflow: hidden;
@@ -91,14 +91,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
-  border-bottom: 1px solid var(--kesson-dev-panel-header-border);
+  border-bottom: 1px solid var(--cs-dev-panel-header-border);
 }
 
 #dev-panel .dev-panel-title {
   margin: 0;
   font-size: 0.85rem;
   letter-spacing: 0.08em;
-  color: var(--kesson-dev-panel-title-color);
+  color: var(--cs-dev-panel-title-color);
 }
 
 #dev-panel .dev-panel-body {
@@ -108,12 +108,12 @@
 }
 
 #dev-panel .accordion-button {
-  background: var(--kesson-dev-panel-accordion-bg);
-  color: var(--kesson-dev-panel-accordion-text);
+  background: var(--cs-dev-panel-accordion-bg);
+  color: var(--cs-dev-panel-accordion-text);
 }
 
 #dev-panel .accordion-button:not(.collapsed) {
-  background: var(--kesson-dev-panel-accordion-active-bg);
+  background: var(--cs-dev-panel-accordion-active-bg);
   color: #fff;
 }
 
@@ -122,13 +122,13 @@
 }
 
 #dev-panel .accordion-body {
-  background: var(--kesson-dev-panel-body-bg);
+  background: var(--cs-dev-panel-body-bg);
 }
 
 #dev-panel .form-label {
   font-size: 0.72rem;
   margin-bottom: 0.25rem;
-  color: var(--kesson-dev-panel-label-color);
+  color: var(--cs-dev-panel-label-color);
 }
 
 #dev-panel .form-range {
@@ -143,14 +143,14 @@
   margin: 0 0 0.75rem;
   font-size: 0.80rem;
   line-height: 1.45;
-  color: var(--kesson-dev-panel-help-color);
+  color: var(--cs-dev-panel-help-color);
 }
 
 #dev-panel .dev-row-help {
   margin-top: 0.2rem;
   font-size: 0.80rem;
   line-height: 1.35;
-  color: var(--kesson-dev-panel-help-sub-color);
+  color: var(--cs-dev-panel-help-sub-color);
 }
 
 #dev-panel .dev-row-meta {
@@ -162,7 +162,7 @@
 
 #dev-panel .dev-value {
   font-size: 0.72rem;
-  color: var(--kesson-dev-panel-value-color);
+  color: var(--cs-dev-panel-value-color);
   min-width: 58px;
   text-align: right;
 }
@@ -175,17 +175,17 @@
 
 #dev-panel .dev-json-status {
   font-size: 0.72rem;
-  color: var(--kesson-dev-panel-status-color);
+  color: var(--cs-dev-panel-status-color);
   margin-top: 6px;
   min-height: 1.2em;
 }
 
 #dev-panel .dev-panel-empty {
   padding: 12px;
-  border: 1px solid var(--kesson-dev-panel-empty-border);
+  border: 1px solid var(--cs-dev-panel-empty-border);
   border-radius: 8px;
-  color: var(--kesson-dev-panel-empty-text);
-  background: var(--kesson-dev-panel-empty-bg);
+  color: var(--cs-dev-panel-empty-text);
+  background: var(--cs-dev-panel-empty-bg);
   font-size: 0.72rem;
 }
 

--- a/src/styles/reports.css
+++ b/src/styles/reports.css
@@ -4,14 +4,14 @@
 #reports-cross-analysis-section {
   position: relative;
   z-index: 5;
-  --reports-font-mono: var(--kesson-font-mono-ui);
-  --reports-font-serif: var(--kesson-font-serif-ui);
+  --reports-font-mono: var(--ds-font-mono-ui);
+  --reports-font-serif: var(--ds-font-serif-ui);
   --reports-font-sans: var(--cs-font-sans-ui);
   --reports-panel-radius: .5rem;
   --reports-panel-padding: .9rem;
   --reports-stack-gap: .9rem;
-  --reports-panel-shadow: var(--kesson-card-shadow-soft);
-  --reports-panel-shadow-hover: var(--kesson-card-shadow-rich);
+  --reports-panel-shadow: var(--ds-card-shadow-soft);
+  --reports-panel-shadow-hover: var(--ds-card-shadow-rich);
   --reports-border-soft: rgba(var(--color-accent), .12);
   --reports-border-base: rgba(var(--color-accent), .2);
   --reports-border-strong: rgba(var(--color-accent), .35);
@@ -23,7 +23,7 @@
   --reports-card-bg: rgba(var(--color-accent), .06);
   --reports-card-border: rgba(var(--color-accent), .14);
   --reports-control-font-size: calc(.8rem + var(--reports-font-step));
-  --reports-control-letter-spacing: var(--kesson-letter-ui-normal);
+  --reports-control-letter-spacing: var(--ds-letter-ui-normal);
   --reports-palette-1-rgb: 157, 172, 194;
   --reports-palette-2-rgb: 241, 190, 82;
   --reports-palette-3-rgb: 92, 145, 255;
@@ -76,12 +76,12 @@
   --bs-btn-active-bg: var(--reports-bg-active);
   --bs-btn-active-border-color: rgba(var(--color-accent), .45);
   --bs-btn-focus-shadow-rgb: var(--color-accent);
-  --bs-btn-border-radius: var(--kesson-radius-sm);
+  --bs-btn-border-radius: var(--ds-radius-sm);
   font-family: var(--reports-font-serif);
   font-size: var(--reports-control-font-size);
-  letter-spacing: var(--kesson-letter-ui-tight);
+  letter-spacing: var(--ds-letter-ui-tight);
   text-transform: none;
-  transition: border-color var(--kesson-transition-standard), background var(--kesson-transition-standard), color var(--kesson-transition-standard), box-shadow var(--kesson-transition-standard);
+  transition: border-color var(--ds-transition-standard), background var(--ds-transition-standard), color var(--ds-transition-standard), box-shadow var(--ds-transition-standard);
 }
 
 #reports-section .is-palette-1 {
@@ -174,9 +174,9 @@
 .reports-subheading {
   margin: 0 0 .65rem;
   color: rgba(var(--color-heading), .82);
-  font-size: var(--kesson-card-title, 1.0rem);
-  letter-spacing: var(--kesson-letter-ui-heading);
-  font-family: var(--kesson-font-serif-display);
+  font-size: var(--ds-card-title, 1.0rem);
+  letter-spacing: var(--ds-letter-ui-heading);
+  font-family: var(--ds-font-serif-display);
   font-weight: 400;
   text-transform: none;
 }
@@ -184,7 +184,7 @@
 .reports-ai-notice {
   margin: 0 0 .85rem;
   color: rgba(var(--color-sub-text), .78);
-  font-size: var(--kesson-card-text, 0.92rem);
+  font-size: var(--ds-card-text, 0.92rem);
   line-height: 1.6;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
@@ -192,7 +192,7 @@
 .reports-level-legend {
   margin: 0 0 .65rem;
   color: rgba(var(--color-sub-text), .7);
-  font-size: var(--kesson-card-text, 0.92rem);
+  font-size: var(--ds-card-text, 0.92rem);
   line-height: 1.6;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   white-space: normal;
@@ -227,12 +227,12 @@
   padding: .72rem 1rem;
   border-color: var(--reports-border-strong);
   border-width: 1px;
-  border-radius: var(--kesson-radius-md);
+  border-radius: var(--ds-radius-md);
   background: rgba(var(--color-accent), .2);
   color: rgba(var(--color-highlight), .92);
   font-family: var(--reports-font-serif);
   font-size: clamp(calc(.79rem + var(--reports-font-step)), calc(2.35vmin + var(--reports-font-step)), calc(.94rem + var(--reports-font-step)));
-  letter-spacing: var(--kesson-letter-ui-tight);
+  letter-spacing: var(--ds-letter-ui-tight);
   box-shadow: 0 0 .8rem rgba(var(--color-accent), .12);
 }
 
@@ -275,7 +275,7 @@
   text-shadow: 0 0 10px rgba(var(--reports-slide-btn-rgb), .1);
   cursor: pointer;
   touch-action: manipulation;
-  transition: border-color var(--kesson-transition-standard), background var(--kesson-transition-standard), color var(--kesson-transition-standard), box-shadow var(--kesson-transition-standard), transform var(--kesson-transition-snappy);
+  transition: border-color var(--ds-transition-standard), background var(--ds-transition-standard), color var(--ds-transition-standard), box-shadow var(--ds-transition-standard), transform var(--ds-transition-snappy);
 }
 
 .reports-slide-btn:hover,
@@ -316,9 +316,9 @@
 }
 
 .report-metric-card {
-  background: var(--kesson-card-bg);
-  border: 1px solid var(--kesson-card-border);
-  border-radius: var(--kesson-radius-lg);
+  background: var(--cs-card-bg);
+  border: 1px solid var(--ds-card-border);
+  border-radius: var(--ds-radius-lg);
   box-shadow: var(--reports-panel-shadow);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
@@ -327,7 +327,7 @@
 .report-metric-label {
   color: rgba(var(--color-heading), .5);
   font-size: calc(.8rem + var(--reports-font-step));
-  letter-spacing: var(--kesson-letter-ui-tight);
+  letter-spacing: var(--ds-letter-ui-tight);
   font-family: var(--reports-font-serif);
 }
 
@@ -357,7 +357,7 @@
 }
 
 .reports-domain-item {
-  --bs-card-border-radius: var(--kesson-radius-lg);
+  --bs-card-border-radius: var(--ds-radius-lg);
   min-height: 3.45rem;
   padding: 0;
   border: 1px solid rgba(var(--reports-palette-rgb), .28);
@@ -367,7 +367,7 @@
   font-family: var(--reports-font-serif);
   font-size: var(--reports-control-font-size);
   letter-spacing: var(--reports-control-letter-spacing);
-  transition: border-color var(--kesson-transition-snappy), background-color var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy), transform var(--kesson-transition-snappy), opacity var(--kesson-transition-snappy);
+  transition: border-color var(--ds-transition-snappy), background-color var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy), transform var(--ds-transition-snappy), opacity var(--ds-transition-snappy);
 }
 
 .reports-domain-item:hover {
@@ -410,7 +410,7 @@
 .reports-domain-item-name {
   color: rgba(var(--color-heading), .82);
   font-size: calc(.8rem + var(--reports-font-step));
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   line-height: 1.2;
   letter-spacing: .03em;
   display: -webkit-box;
@@ -432,7 +432,7 @@
 }
 
 .reports-md-modal-content {
-  background: var(--kesson-offcanvas-bg);
+  background: var(--cs-offcanvas-bg);
   color: rgba(var(--color-heading), .92);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -500,7 +500,7 @@
 
 .reports-phase8-card {
   cursor: pointer;
-  transition: border-color var(--kesson-transition-snappy), background-color var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy), transform var(--kesson-transition-snappy);
+  transition: border-color var(--ds-transition-snappy), background-color var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy), transform var(--ds-transition-snappy);
 }
 
 .reports-phase8-card:hover {
@@ -520,9 +520,9 @@
   object-fit: cover;
   object-position: top;
   border-bottom: 1px solid rgba(var(--reports-palette-rgb), .18);
-  border-radius: var(--kesson-radius-lg) var(--kesson-radius-lg) 0 0;
+  border-radius: var(--ds-radius-lg) var(--ds-radius-lg) 0 0;
   opacity: .85;
-  transition: opacity var(--kesson-transition-snappy);
+  transition: opacity var(--ds-transition-snappy);
 }
 
 .reports-domain-item:hover .reports-domain-item-thumbnail {
@@ -802,7 +802,7 @@
 .hover-grid-cell-name {
   font-size: 0.85rem;
   font-weight: 400;
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   letter-spacing: 0.06em;
   color: rgba(241, 245, 249, 0.92);
   margin-bottom: 0.75rem;
@@ -824,7 +824,7 @@
 }
 
 .hover-grid-cell-content {
-  font-size: var(--kesson-card-text, 0.92rem);
+  font-size: var(--ds-card-text, 0.92rem);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.6;
   color: rgba(255, 255, 255, 0.85);
@@ -920,8 +920,8 @@
   font-size: 1.4rem;
   font-weight: 400;
   color: rgba(241, 245, 249, 0.92);
-  font-family: var(--kesson-font-serif-display, 'Noto Serif JP', serif);
-  letter-spacing: var(--kesson-letter-ui-heading);
+  font-family: var(--ds-font-serif-display, 'Noto Serif JP', serif);
+  letter-spacing: var(--ds-letter-ui-heading);
 }
 
 .hover-grid-modal-status {
@@ -972,7 +972,7 @@
 
 /* Button in REPORTS section to open modal */
 #reports-hover-grid-open-btn {
-  font-family: var(--kesson-font-serif-display, 'Noto Serif JP', serif);
+  font-family: var(--ds-font-serif-display, 'Noto Serif JP', serif);
   font-size: 1rem;
   letter-spacing: 0.06em;
   padding: 0.7rem 2rem;

--- a/src/styles/shell-content.css
+++ b/src/styles/shell-content.css
@@ -1,24 +1,24 @@
 /* shell-content.css — non-token shell styles */
 
 .btn-kesson-action {
-  --bs-btn-color: var(--kesson-action-text);
-  --bs-btn-bg: var(--kesson-action-bg);
-  --bs-btn-border-color: var(--kesson-action-border);
-  --bs-btn-hover-color: var(--kesson-action-text-hover);
-  --bs-btn-hover-bg: var(--kesson-action-bg-hover);
+  --bs-btn-color: var(--cs-action-text);
+  --bs-btn-bg: var(--cs-action-bg);
+  --bs-btn-border-color: var(--cs-action-border);
+  --bs-btn-hover-color: var(--cs-action-text-hover);
+  --bs-btn-hover-bg: var(--cs-action-bg-hover);
   --bs-btn-hover-border-color: rgba(var(--color-accent), 0.32);
-  --bs-btn-active-color: var(--kesson-action-text-hover);
-  --bs-btn-active-bg: var(--kesson-action-bg-hover);
+  --bs-btn-active-color: var(--cs-action-text-hover);
+  --bs-btn-active-bg: var(--cs-action-bg-hover);
   --bs-btn-active-border-color: rgba(var(--color-accent), 0.36);
   --bs-btn-focus-shadow-rgb: var(--color-accent);
-  font-family: var(--kesson-font-serif-ui);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-family: var(--ds-font-serif-ui);
+  letter-spacing: var(--ds-letter-ui-wide);
   text-transform: uppercase;
 }
 
 #graphic-switcher {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 0.7rem);
+  top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 0.7rem);
   left: 1rem;
   z-index: 58;
   display: flex;
@@ -28,8 +28,8 @@
 }
 
 .graphic-switcher-label {
-  font-family: var(--kesson-font-serif-display);
-  font-size: var(--kesson-graphic-switcher-label, 0.68rem);
+  font-family: var(--ds-font-serif-display);
+  font-size: var(--cs-graphic-switcher-label, 0.68rem);
   letter-spacing: 0.08em;
   color: rgba(var(--color-sub-text), 0.45);
   margin-right: 0.4rem;
@@ -44,8 +44,8 @@
   border-bottom: 1.5px solid transparent;
   padding: 0.2rem 0.5rem 0.22rem;
   color: rgba(var(--color-sub-text), 0.42);
-  font-family: var(--kesson-font-serif-display);
-  font-size: var(--kesson-graphic-switcher-btn, 0.88rem);
+  font-family: var(--ds-font-serif-display);
+  font-size: var(--cs-graphic-switcher-btn, 0.88rem);
   letter-spacing: 0.06em;
   cursor: pointer;
   transition: color 0.25s ease, border-color 0.25s ease;
@@ -74,7 +74,7 @@
   border: none;
   padding: 0;
   color: rgba(var(--color-heading), 0.9);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   font-size: clamp(0.80rem, 2.8vmin, 1.1rem);
   letter-spacing: clamp(0.05em, 0.4vmin, 0.15em);
   text-shadow: 0 0 12px rgba(var(--color-accent), 0.5), 0 0 4px rgba(0, 0, 0, 0.8);
@@ -91,7 +91,7 @@
 
 .nav-label:focus-visible,
 .nav-label.is-nav-focused {
-  outline: 2px solid var(--kesson-focus-ring);
+  outline: 2px solid var(--ds-focus-ring);
   outline-offset: 4px;
   filter: blur(0px) !important;
   text-shadow: 0 0 18px rgba(110, 160, 255, 0.72), 0 0 6px rgba(0, 0, 0, 0.85);
@@ -147,9 +147,9 @@
 
 h1 {
   color: rgba(var(--color-heading), 0.95);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   font-weight: 400;
-  font-size: var(--kesson-h1-size);
+  font-size: var(--ds-h1-size);
   letter-spacing: clamp(0.15em, 1.2vmin, 0.5em);
   line-height: 1.6;
   margin-bottom: 0.6rem;
@@ -166,18 +166,18 @@ h1 {
 }
 
 .tagline {
-  font-size: var(--kesson-overlay-tagline, 0.80rem);
+  font-size: var(--ds-overlay-tagline, 0.80rem);
   color: rgba(var(--color-heading), 0.75);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   letter-spacing: 0.05em;
   line-height: 1.8;
   text-shadow: 0 0 30px rgba(var(--color-accent), 0.3);
 }
 
 .tagline-en {
-  font-size: var(--kesson-overlay-tagline-en, 0.80rem);
+  font-size: var(--ds-overlay-tagline-en, 0.80rem);
   color: rgba(var(--color-heading), 0.55);
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   letter-spacing: 0.03em;
   line-height: 1.6;
   text-shadow: 0 0 30px rgba(var(--color-accent), 0.3);
@@ -188,7 +188,7 @@ html[lang="en"] h1 {
   letter-spacing: clamp(0.05em, 0.4vmin, 0.15em);
   line-height: 1.3;
   margin-bottom: 0.4rem;
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
 }
 
 html[lang="en"] #taglines {
@@ -218,10 +218,10 @@ html[lang="en"] #taglines {
 #scroll-hint-top span,
 #left-kesson-link span {
   display: block;
-  font-size: var(--kesson-font-size-ui-xs, 0.80rem);
-  color: var(--kesson-ui-label-color);
-  font-family: var(--kesson-font-serif-ui);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-size: var(--ds-font-size-ui-xs, 0.80rem);
+  color: var(--ds-ui-label-color);
+  font-family: var(--ds-font-serif-ui);
+  letter-spacing: var(--ds-letter-ui-wide);
 }
 
 #scroll-hint span,
@@ -232,8 +232,8 @@ html[lang="en"] #taglines {
 #scroll-hint .arrow,
 #scroll-hint-top .arrow,
 #left-kesson-link .arrow {
-  font-size: var(--kesson-font-size-ui-arrow, clamp(0.7rem, 3.5vmin, 1.2rem));
-  color: var(--kesson-ui-arrow-color);
+  font-size: var(--ds-font-size-ui-arrow, clamp(0.7rem, 3.5vmin, 1.2rem));
+  color: var(--ds-ui-arrow-color);
 }
 
 #left-kesson-link {
@@ -255,17 +255,17 @@ html[lang="en"] #taglines {
 
 #left-kesson-link:hover span,
 #left-kesson-link:hover .arrow {
-  color: var(--kesson-ui-label-hover-color);
+  color: var(--ds-ui-label-hover-color);
 }
 
 #left-kesson-link:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring-soft);
+  outline: 2px solid var(--ds-focus-ring-soft);
   outline-offset: 3px;
 }
 
 #scroll-hint-top {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 6px);
+  top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 6px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -290,12 +290,12 @@ html[lang="en"] #taglines {
 
 #scroll-hint-top:hover span,
 #scroll-hint-top:hover .arrow {
-  color: var(--kesson-ui-label-hover-color);
+  color: var(--ds-ui-label-hover-color);
 }
 
 #control-guide {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 0.7rem);
+  top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 0.7rem);
   right: 1rem;
   z-index: 10;
   pointer-events: none;
@@ -312,10 +312,10 @@ html[lang="en"] #taglines {
 }
 
 #control-guide .guide-key {
-  font-size: var(--kesson-control-guide, 0.80rem);
+  font-size: var(--ds-control-guide, 0.80rem);
   color: rgba(var(--color-sub-text), 0.35);
-  font-family: var(--kesson-font-mono-ui);
-  letter-spacing: var(--kesson-letter-ui-tight);
+  font-family: var(--ds-font-mono-ui);
+  letter-spacing: var(--ds-letter-ui-tight);
   white-space: nowrap;
 }
 
@@ -325,10 +325,10 @@ html[lang="en"] #taglines {
 }
 
 #control-guide .guide-action {
-  font-size: var(--kesson-control-guide, 0.80rem);
+  font-size: var(--ds-control-guide, 0.80rem);
   color: rgba(var(--color-sub-text), 0.3);
-  font-family: var(--kesson-font-serif-ui);
-  letter-spacing: var(--kesson-letter-ui-normal);
+  font-family: var(--ds-font-serif-ui);
+  letter-spacing: var(--ds-letter-ui-normal);
   white-space: nowrap;
 }
 
@@ -343,18 +343,18 @@ html[lang="en"] #taglines {
 /* ── 共通パネル基盤 ── */
 .kesson-panel {
   background: var(--cs-surface-2);
-  border: 1px solid var(--kesson-card-border);
-  border-radius: var(--kesson-radius-lg);
-  box-shadow: var(--kesson-card-shadow-soft);
+  border: 1px solid var(--ds-card-border);
+  border-radius: var(--ds-radius-lg);
+  box-shadow: var(--ds-card-shadow-soft);
   color: rgba(var(--color-heading), 0.82);
 }
 
 .card.kesson-card {
-  --bs-card-bg: var(--kesson-card-bg);
+  --bs-card-bg: var(--cs-card-bg);
   background-color: var(--bs-card-bg);
   background-image: none;
   border: 1px solid rgba(var(--color-accent), 0.1);
-  transition: transform var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy);
+  transition: transform var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy);
   cursor: pointer;
 }
 
@@ -374,7 +374,7 @@ html[lang="en"] #taglines {
 
 .kesson-card .card-title {
   color: #fff;
-  font-size: var(--kesson-card-title, 1.0rem);
+  font-size: var(--ds-card-title, 1.0rem);
   font-family: 'Noto Serif JP', Georgia, serif;
 }
 
@@ -410,7 +410,7 @@ html[lang="en"] #taglines {
   border: 1px solid rgba(var(--color-accent), 0.16);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22);
   overflow: hidden;
-  transition: transform var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy), border-color var(--kesson-transition-snappy);
+  transition: transform var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy), border-color var(--ds-transition-snappy);
 }
 
 .img-card-link > .img-card {
@@ -490,7 +490,7 @@ html[lang="en"] #taglines {
   bottom: 24px;
   right: 24px;
   z-index: 20;
-  font-size: var(--kesson-surface-btn, 0.80rem);
+  font-size: var(--ds-surface-btn, 0.80rem);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.6s ease, background 0.3s ease, color 0.3s ease;
@@ -501,18 +501,18 @@ html[lang="en"] #taglines {
 .section-content-wrap {
   position: relative;
   z-index: 20;
-  padding: var(--kesson-section-content-padding);
+  padding: var(--ds-section-content-padding);
 }
 
 /* .creation-section-shell removed — techo#76 KS 統一 */
 
 .section-heading {
-  font-size: var(--kesson-section-heading, 0.80rem);
+  font-size: var(--ds-section-heading, 0.80rem);
   font-weight: 400;
   color: rgba(var(--color-sub-text), 0.5);
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   margin: 0 0 0.85rem;
 }
 
@@ -580,18 +580,18 @@ html[lang="en"] #taglines {
 }
 
 .tech-footer-line {
-  font-size: var(--kesson-footer-line, 0.80rem);
+  font-size: var(--ds-footer-line, 0.80rem);
   color: rgba(150, 175, 210, 0.25);
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   letter-spacing: 0.06em;
   line-height: 1.8;
 }
 
 .footer-signature {
   margin-top: 0.55rem;
-  font-size: var(--kesson-footer-signature-size, 0.80rem);
+  font-size: var(--ds-footer-signature-size, 0.80rem);
   color: rgba(195, 214, 241, 0.68);
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   letter-spacing: 0.06em;
   line-height: 1.5;
 }
@@ -638,7 +638,7 @@ html[lang="en"] #taglines {
 
 @media (max-width: 767.98px) {
   #graphic-switcher {
-    top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 0.5rem);
+    top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height)) + 0.5rem);
     left: 0.6rem;
   }
 

--- a/src/styles/slides.css
+++ b/src/styles/slides.css
@@ -16,9 +16,9 @@
   --slide-glass-border: rgba(148, 163, 184, 0.14);
   --slide-border-subtle: rgba(148, 163, 184, 0.08);
   --slide-border-medium: rgba(148, 163, 184, 0.18);
-  --slide-font-heading: var(--kesson-font-serif-display);
+  --slide-font-heading: var(--ds-font-serif-display);
   --slide-font-body: "Inter", "Noto Sans JP", system-ui, sans-serif;
-  --slide-font-mono: var(--kesson-font-mono-ui);
+  --slide-font-mono: var(--ds-font-mono-ui);
   --slide-radius: 16px;
   --slide-radius-sm: 8px;
 
@@ -173,7 +173,7 @@
 
 .slide-viewer-close:focus-visible,
 .slide-viewer-fullscreen:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring, rgba(100, 150, 255, 0.86));
+  outline: 2px solid var(--ds-focus-ring, rgba(100, 150, 255, 0.86));
   outline-offset: 2px;
 }
 

--- a/src/styles/startup-errors.css
+++ b/src/styles/startup-errors.css
@@ -20,7 +20,7 @@
 
 #app-startup-warning-banner {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height, 3.4rem)) + 0.6rem);
+  top: calc(var(--cs-topbar-actual-height, var(--cs-topbar-height, 3.4rem)) + 0.6rem);
   right: 0.75rem;
   max-width: min(28rem, calc(100vw - 1.5rem));
   padding: 0.7rem 0.9rem;
@@ -29,7 +29,7 @@
   border-radius: 0.45rem;
   background: rgba(57, 40, 12, 0.9);
   color: #ffe7bb;
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   font-size: 0.84rem;
   line-height: 1.5;
   box-shadow: 0 0 18px rgba(0, 0, 0, 0.24);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,13 +1,15 @@
 /*
  * pd design-system/tokens.css (--ds-*) を参照。
  * @import 失敗時は各 token の fallback で従来動作。
- * 参照: techo#126 / pd#84 / cs#230
+ * 参照: techo#126 / pd#84 / cs#230 / techo#128 (Phase 1b — --kesson-* 全廃)
  */
 @import url('../../../project-design/design-system/tokens.css');
 
 :root {
   /* Intentional difference vs awareness-space:
      creation-space keeps a larger UI scale and surface-based action styling. */
+
+  /* === --color-* (--ds-color-* alias) === */
   --color-accent: var(--ds-color-accent, 100, 150, 255);
   --color-sub-text: var(--ds-color-sub-text, 180, 200, 230);
   --color-highlight: var(--ds-color-highlight, 220, 230, 245);
@@ -15,60 +17,137 @@
   --color-heading: var(--ds-color-heading, 255, 255, 255);
   --color-bg-body: var(--ds-color-bg-body, #050508);
 
-  --kesson-font-serif-display: var(--ds-font-serif-display, "Noto Serif JP", "Yu Mincho", "MS PMincho", serif);
-  --kesson-font-serif-ui: var(--ds-font-serif-ui, 'Georgia', "Noto Serif JP", serif);
+  /* === cs 個性 (typography / surface / report) === */
   --cs-font-sans-ui: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Meiryo", system-ui, sans-serif;
-  --kesson-font-mono-ui: var(--ds-font-mono-ui, 'SF Mono', 'Fira Code', 'Consolas', monospace);
   --cs-font-mono-system: ui-monospace, SFMono-Regular, 'SF Mono', 'Consolas', monospace;
-  --kesson-font-size-ui-xs: var(--ds-font-size-ui-xs, 0.85rem);
-  --kesson-font-size-ui-sm: var(--ds-font-size-ui-sm, 0.88rem);
-  --kesson-font-size-ui-arrow: var(--ds-font-size-ui-arrow, clamp(0.7rem, 3.5vmin, 1.2rem));
   --reports-font-step: 0rem;
-  --kesson-letter-ui-tight: var(--ds-letter-ui-tight, 0.03em);
-  --kesson-letter-ui-normal: var(--ds-letter-ui-normal, 0.06em);
-  --kesson-letter-ui-wide: var(--ds-letter-ui-wide, 0.1em);
-  --kesson-letter-ui-heading: var(--ds-letter-ui-heading, 0.15em);
-
-  --kesson-radius-sm: var(--ds-radius-sm, 2px);
-  --kesson-radius-md: var(--ds-radius-md, 3px);
-  --kesson-radius-lg: var(--ds-radius-lg, 4px);
-  --kesson-transition-standard: var(--ds-transition-standard, 0.3s ease);
-  --kesson-transition-snappy: var(--ds-transition-snappy, 0.2s ease);
-
-  --kesson-focus-ring: var(--ds-focus-ring, rgba(var(--color-accent), 0.86));
-  --kesson-focus-ring-soft: var(--ds-focus-ring-soft, rgba(var(--color-accent), 0.8));
-  --kesson-ui-label-color: var(--ds-ui-label-color, rgba(var(--color-sub-text), 0.3));
-  --kesson-ui-arrow-color: var(--ds-ui-arrow-color, rgba(var(--color-sub-text), 0.25));
-  --kesson-ui-label-hover-color: var(--ds-ui-label-hover-color, rgba(var(--color-sub-text), 0.6));
-  --kesson-action-bg: rgba(var(--color-accent), 0.1);
-  --kesson-action-border: rgba(var(--color-accent), 0.1);
-  --kesson-action-text: rgba(var(--color-sub-text), 0.5);
-  --kesson-action-bg-hover: var(--kesson-card-bg);
-  --kesson-action-text-hover: rgba(var(--color-heading), 0.7);
-  --kesson-card-border: var(--ds-card-border, rgba(var(--color-accent), 0.1));
-  --kesson-card-border-strong: var(--ds-card-border-strong, rgba(var(--color-accent), 0.28));
-  --kesson-card-shadow-soft: var(--ds-card-shadow-soft, 0 4px 12px rgba(var(--color-accent), 0.15));
-  --kesson-card-shadow-rich: var(--ds-card-shadow-rich, 0 8px 24px rgba(0, 0, 0, 0.38), 0 0 12px rgba(var(--color-accent), 0.15));
-  --kesson-error-color: var(--ds-error-color, #f87171);
-  --kesson-error-size: var(--ds-error-size, 0.8rem);
-
-  --kesson-section-content-padding: var(--ds-section-content-padding, 1rem 1.5rem 0);
-  --kesson-section-grid-margin-top: 1.5rem;
+  --cs-surface-1: rgba(20, 25, 40, 0.3);
   --cs-surface-2: rgba(20, 25, 40, 0.6);
   --cs-surface-3: rgba(20, 25, 40, 0.9);
-  --kesson-card-bg: var(--cs-surface-3);
 
-  --kesson-section-heading: var(--ds-section-heading, 0.88rem);
-  --kesson-card-title: var(--ds-card-title, 1.0rem);
-  --kesson-card-text: var(--ds-card-text, 0.92rem);
-  --kesson-card-summary: var(--ds-card-summary, 0.92rem);
-  --kesson-overlay-tagline: var(--ds-overlay-tagline, 0.92rem);
-  --kesson-overlay-tagline-en: var(--ds-overlay-tagline-en, 0.88rem);
-  --kesson-control-guide: var(--ds-control-guide, 0.82rem);
-  --kesson-footer-line: var(--ds-footer-line, 0.82rem);
-  --kesson-surface-btn: var(--ds-surface-btn, 0.88rem);
-  --kesson-footer-signature-size: var(--ds-footer-signature-size, 0.88rem);
-  --kesson-graphic-switcher-label: 0.88rem;
-  --kesson-graphic-switcher-btn: 0.88rem;
-  --kesson-h1-size: var(--ds-h1-size, clamp(1.0rem, 5.5vmin, 2.0rem));
+  /* === --cs-* (旧 --kesson-* 取り込み, see techo#128 Phase 1b) === */
+  /* --- action-* --- */
+  --cs-action-bg-hover: var(--cs-card-bg);
+  --cs-action-bg: rgba(var(--color-accent), 0.1);
+  --cs-action-border: rgba(var(--color-accent), 0.1);
+  --cs-action-text-hover: rgba(var(--color-heading), 0.7);
+  --cs-action-text: rgba(var(--color-sub-text), 0.5);
+  /* --- card-* --- */
+  --cs-card-bg: var(--cs-surface-3);
+  /* --- dev-hud-* --- */
+  --cs-dev-hud-bg: rgba(8, 14, 26, 0.84);
+  --cs-dev-hud-border: rgba(120, 164, 235, 0.42);
+  --cs-dev-hud-btn-bg-hover: rgba(116, 165, 244, 0.32);
+  --cs-dev-hud-btn-bg: rgba(100, 152, 246, 0.2);
+  --cs-dev-hud-btn-border: rgba(130, 170, 240, 0.45);
+  --cs-dev-hud-btn-text: rgba(238, 246, 255, 0.96);
+  --cs-dev-hud-font-size: 0.80rem;
+  --cs-dev-hud-input-bg: rgba(10, 18, 32, 0.88);
+  --cs-dev-hud-input-border: rgba(130, 170, 240, 0.35);
+  --cs-dev-hud-input-text: rgba(220, 235, 255, 0.95);
+  --cs-dev-hud-text: rgba(205, 224, 255, 0.92);
+  /* --- dev-panel-* --- */
+  --cs-dev-panel-accordion-active-bg: rgba(46, 72, 116, 0.7);
+  --cs-dev-panel-accordion-bg: rgba(26, 40, 70, 0.5);
+  --cs-dev-panel-accordion-text: rgba(222, 235, 255, 0.92);
+  --cs-dev-panel-bg: rgba(7, 12, 24, 0.96);
+  --cs-dev-panel-body-bg: rgba(11, 20, 38, 0.75);
+  --cs-dev-panel-border: rgba(140, 178, 255, 0.3);
+  --cs-dev-panel-empty-bg: rgba(11, 20, 38, 0.6);
+  --cs-dev-panel-empty-border: rgba(140, 178, 255, 0.25);
+  --cs-dev-panel-empty-text: rgba(201, 221, 255, 0.85);
+  --cs-dev-panel-header-border: rgba(140, 178, 255, 0.25);
+  --cs-dev-panel-help-color: rgba(176, 201, 238, 0.82);
+  --cs-dev-panel-help-sub-color: rgba(162, 188, 228, 0.72);
+  --cs-dev-panel-label-color: rgba(188, 211, 245, 0.95);
+  --cs-dev-panel-status-color: rgba(201, 221, 255, 0.8);
+  --cs-dev-panel-title-color: rgba(223, 236, 255, 0.95);
+  --cs-dev-panel-value-color: rgba(201, 221, 255, 0.86);
+  /* --- dev-toggle-* --- */
+  --cs-dev-toggle-bg-hover: rgba(30, 45, 70, 0.82);
+  --cs-dev-toggle-bg: rgba(20, 30, 50, 0.7);
+  --cs-dev-toggle-border: rgba(var(--color-accent), 0.15);
+  --cs-dev-toggle-text-hover: rgba(210, 225, 255, 0.95);
+  --cs-dev-toggle-text: rgba(180, 200, 255, 0.75);
+  /* --- md-* --- */
+  --cs-md-em: rgba(200, 215, 240, 0.8);
+  --cs-md-h1-strong: rgba(240, 245, 255, 0.95);
+  --cs-md-h1: rgba(240, 245, 255, 0.92);
+  --cs-md-h2: rgba(230, 240, 255, 0.88);
+  --cs-md-h3: rgba(220, 230, 250, 0.85);
+  --cs-md-h4: rgba(210, 225, 245, 0.8);
+  --cs-md-inline-code-bg: rgba(60, 90, 150, 0.12);
+  --cs-md-inline-code: rgba(180, 210, 255, 0.85);
+  --cs-md-link-hover: rgba(160, 195, 255, 1);
+  --cs-md-link: rgba(var(--color-link), 0.85);
+  --cs-md-pdf-link-hover-bg: rgba(60, 90, 150, 0.1);
+  --cs-md-pdf-link-hover: rgba(200, 220, 255, 0.9);
+  --cs-md-pdf-link: rgba(160, 185, 240, 0.7);
+  --cs-md-pre-bg: rgba(8, 12, 24, 0.6);
+  --cs-md-provenance: rgba(140, 160, 200, 0.4);
+  --cs-md-quote: rgba(200, 215, 240, 0.7);
+  --cs-md-strong: rgba(240, 245, 255, 0.95);
+  --cs-md-table-cell-text: rgba(200, 215, 240, 0.75);
+  --cs-md-table-head-bg: rgba(40, 60, 100, 0.2);
+  --cs-md-table-head-text: rgba(220, 230, 250, 0.9);
+  /* --- offcanvas-* --- */
+  --cs-offcanvas-bg: rgba(10, 14, 26, 0.98);
+  --cs-offcanvas-heading: #e2e8f0;
+  --cs-offcanvas-link: #f59e0b;
+  --cs-offcanvas-text: #94a3b8;
+  --cs-offcanvas-width: 85%;
+  /* --- scrollbar-* --- */
+  --cs-scrollbar-thumb: #1e293b;
+  /* --- section-* --- */
+  --cs-section-grid-margin-top: 1.5rem;
+  /* --- topbar-* --- */
+  --cs-topbar-alpha-soft: 0.10;
+  --cs-topbar-alpha-strong: 0.10;
+  --cs-topbar-bg-end: rgba(10, 14, 24, var(--cs-topbar-alpha-soft));
+  --cs-topbar-bg-start: rgba(10, 14, 24, var(--cs-topbar-alpha-strong));
+  --cs-topbar-blur: 14px;
+  --cs-topbar-border-alpha: 0.22;
+  --cs-topbar-border-color: rgba(130, 170, 240, var(--cs-topbar-border-alpha));
+  --cs-topbar-credit-size: 0.84rem;
+  --cs-topbar-divider-color: rgba(170, 192, 228, 0.42);
+  --cs-topbar-height: 3.25rem;
+  --cs-topbar-lang-bg: rgba(70, 102, 160, 0.16);
+  --cs-topbar-lang-border: rgba(130, 170, 240, 0.25);
+  --cs-topbar-lang-color: rgba(218, 232, 255, 0.9);
+  --cs-topbar-link-color: rgba(205, 220, 244, 0.78);
+  --cs-topbar-link-hover-bg: rgba(120, 165, 240, 0.2);
+  --cs-topbar-link-hover-color: rgba(236, 244, 255, 0.98);
+  --cs-topbar-link-size: 0.88rem;
+  --cs-topbar-main-title-size-sm: 0.86rem;
+  --cs-topbar-main-title-size: clamp(0.96rem, 1.85vw, 1.38rem);
+  --cs-topbar-meta-author-color: rgba(184, 203, 234, 0.74);
+  --cs-topbar-meta-author-size: 0.84rem;
+  --cs-topbar-meta-color: rgba(186, 204, 234, 0.72);
+  --cs-topbar-meta-size: 0.86rem;
+  --cs-topbar-nav-bg: rgba(9, 13, 24, 0.82);
+  --cs-topbar-nav-border: rgba(130, 170, 240, 0.2);
+  --cs-topbar-note-color: rgba(165, 214, 255, 0.74);
+  --cs-topbar-note-divider-color: rgba(130, 170, 240, 0.2);
+  --cs-topbar-note-size-sm: var(--cs-topbar-note-size);
+  --cs-topbar-note-size: 0.88rem;
+  --cs-topbar-saturate: 145%;
+  --cs-topbar-shadow-alpha: 0.26;
+  --cs-topbar-subtitle-color: rgba(205, 220, 244, 0.76);
+  --cs-topbar-subtitle-size-md: 0.88rem;
+  --cs-topbar-subtitle-size: var(--cs-topbar-title-size);
+  --cs-topbar-title-color: rgba(228, 238, 255, 0.92);
+  --cs-topbar-title-hover-color: rgba(242, 248, 255, 1);
+  --cs-topbar-title-size: clamp(0.88rem, 1.1vw, 0.96rem);
+  --cs-topbar-toggler-border: rgba(145, 178, 242, 0.55);
+  --cs-topbar-toggler-focus: rgba(140, 180, 252, 0.35);
+  /* --- viewer-* --- */
+  --cs-viewer-glass-bg: rgba(12, 18, 30, 0.88);
+  --cs-viewer-glass-border: rgba(var(--color-accent), 0.06);
+  --cs-viewer-glass-shadow: 0 0 60px rgba(0, 0, 0, 0.4), 0 0 120px rgba(30, 60, 120, 0.1), inset 0 0 60px rgba(20, 40, 80, 0.05);
+  --cs-viewer-overlay-closed: rgba(5, 10, 20, 0);
+  --cs-viewer-overlay-open: rgba(5, 10, 20, 0.5);
+  --cs-viewer-x-handle: rgba(var(--color-embed-handle), 0.7);
+  /* --- graphic-switcher-* --- */
+  --cs-graphic-switcher-btn: 0.88rem;
+  --cs-graphic-switcher-label: 0.88rem;
 }

--- a/src/styles/topbar.css
+++ b/src/styles/topbar.css
@@ -1,43 +1,43 @@
 :root {
-  --kesson-topbar-main-title-size: clamp(0.96rem, 1.85vw, 1.38rem);
-  --kesson-topbar-main-title-size-sm: 0.86rem;
-  --kesson-topbar-title-size: clamp(0.88rem, 1.1vw, 0.96rem);
-  --kesson-topbar-subtitle-size: var(--kesson-topbar-title-size);
-  --kesson-topbar-subtitle-size-md: 0.88rem;
-  --kesson-topbar-link-size: 0.88rem;
-  --kesson-topbar-note-size: 0.88rem;
-  --kesson-topbar-note-size-sm: var(--kesson-topbar-note-size);
-  --kesson-topbar-credit-size: 0.84rem;
-  --kesson-topbar-meta-size: 0.86rem;
-  --kesson-topbar-meta-author-size: 0.84rem;
-  --kesson-topbar-bg-start: rgba(10, 14, 24, var(--kesson-topbar-alpha-strong));
-  --kesson-topbar-bg-end: rgba(10, 14, 24, var(--kesson-topbar-alpha-soft));
-  --kesson-topbar-border-color: rgba(130, 170, 240, var(--kesson-topbar-border-alpha));
-  --kesson-topbar-divider-color: rgba(170, 192, 228, 0.42);
-  --kesson-topbar-title-color: rgba(228, 238, 255, 0.92);
-  --kesson-topbar-title-hover-color: rgba(242, 248, 255, 1);
-  --kesson-topbar-subtitle-color: rgba(205, 220, 244, 0.76);
-  --kesson-topbar-meta-color: rgba(186, 204, 234, 0.72);
-  --kesson-topbar-meta-author-color: rgba(184, 203, 234, 0.74);
-  --kesson-topbar-link-color: rgba(205, 220, 244, 0.78);
-  --kesson-topbar-link-hover-color: rgba(236, 244, 255, 0.98);
-  --kesson-topbar-link-hover-bg: rgba(120, 165, 240, 0.2);
-  --kesson-topbar-note-divider-color: rgba(130, 170, 240, 0.2);
-  --kesson-topbar-note-color: rgba(165, 214, 255, 0.74);
-  --kesson-topbar-lang-color: rgba(218, 232, 255, 0.9);
-  --kesson-topbar-lang-border: rgba(130, 170, 240, 0.25);
-  --kesson-topbar-lang-bg: rgba(70, 102, 160, 0.16);
-  --kesson-topbar-nav-bg: rgba(9, 13, 24, 0.82);
-  --kesson-topbar-nav-border: rgba(130, 170, 240, 0.2);
-  --kesson-topbar-toggler-border: rgba(145, 178, 242, 0.55);
-  --kesson-topbar-toggler-focus: rgba(140, 180, 252, 0.35);
-  --kesson-topbar-height: 3.25rem;
-  --kesson-topbar-alpha-strong: 0.10;
-  --kesson-topbar-alpha-soft: 0.10;
-  --kesson-topbar-border-alpha: 0.22;
-  --kesson-topbar-shadow-alpha: 0.26;
-  --kesson-topbar-blur: 14px;
-  --kesson-topbar-saturate: 145%;
+  --cs-topbar-main-title-size: clamp(0.96rem, 1.85vw, 1.38rem);
+  --cs-topbar-main-title-size-sm: 0.86rem;
+  --cs-topbar-title-size: clamp(0.88rem, 1.1vw, 0.96rem);
+  --cs-topbar-subtitle-size: var(--cs-topbar-title-size);
+  --cs-topbar-subtitle-size-md: 0.88rem;
+  --cs-topbar-link-size: 0.88rem;
+  --cs-topbar-note-size: 0.88rem;
+  --cs-topbar-note-size-sm: var(--cs-topbar-note-size);
+  --cs-topbar-credit-size: 0.84rem;
+  --cs-topbar-meta-size: 0.86rem;
+  --cs-topbar-meta-author-size: 0.84rem;
+  --cs-topbar-bg-start: rgba(10, 14, 24, var(--cs-topbar-alpha-strong));
+  --cs-topbar-bg-end: rgba(10, 14, 24, var(--cs-topbar-alpha-soft));
+  --cs-topbar-border-color: rgba(130, 170, 240, var(--cs-topbar-border-alpha));
+  --cs-topbar-divider-color: rgba(170, 192, 228, 0.42);
+  --cs-topbar-title-color: rgba(228, 238, 255, 0.92);
+  --cs-topbar-title-hover-color: rgba(242, 248, 255, 1);
+  --cs-topbar-subtitle-color: rgba(205, 220, 244, 0.76);
+  --cs-topbar-meta-color: rgba(186, 204, 234, 0.72);
+  --cs-topbar-meta-author-color: rgba(184, 203, 234, 0.74);
+  --cs-topbar-link-color: rgba(205, 220, 244, 0.78);
+  --cs-topbar-link-hover-color: rgba(236, 244, 255, 0.98);
+  --cs-topbar-link-hover-bg: rgba(120, 165, 240, 0.2);
+  --cs-topbar-note-divider-color: rgba(130, 170, 240, 0.2);
+  --cs-topbar-note-color: rgba(165, 214, 255, 0.74);
+  --cs-topbar-lang-color: rgba(218, 232, 255, 0.9);
+  --cs-topbar-lang-border: rgba(130, 170, 240, 0.25);
+  --cs-topbar-lang-bg: rgba(70, 102, 160, 0.16);
+  --cs-topbar-nav-bg: rgba(9, 13, 24, 0.82);
+  --cs-topbar-nav-border: rgba(130, 170, 240, 0.2);
+  --cs-topbar-toggler-border: rgba(145, 178, 242, 0.55);
+  --cs-topbar-toggler-focus: rgba(140, 180, 252, 0.35);
+  --cs-topbar-height: 3.25rem;
+  --cs-topbar-alpha-strong: 0.10;
+  --cs-topbar-alpha-soft: 0.10;
+  --cs-topbar-border-alpha: 0.22;
+  --cs-topbar-shadow-alpha: 0.26;
+  --cs-topbar-blur: 14px;
+  --cs-topbar-saturate: 145%;
 }
 
 #kesson-topbar {
@@ -49,13 +49,13 @@
   z-index: 60;
   background: linear-gradient(
     to bottom,
-    var(--kesson-topbar-bg-start) 0%,
-    var(--kesson-topbar-bg-end) 100%
+    var(--cs-topbar-bg-start) 0%,
+    var(--cs-topbar-bg-end) 100%
   );
-  border-bottom: 1px solid var(--kesson-topbar-border-color);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, var(--kesson-topbar-shadow-alpha));
-  backdrop-filter: blur(var(--kesson-topbar-blur)) saturate(var(--kesson-topbar-saturate));
-  -webkit-backdrop-filter: blur(var(--kesson-topbar-blur)) saturate(var(--kesson-topbar-saturate));
+  border-bottom: 1px solid var(--cs-topbar-border-color);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, var(--cs-topbar-shadow-alpha));
+  backdrop-filter: blur(var(--cs-topbar-blur)) saturate(var(--cs-topbar-saturate));
+  -webkit-backdrop-filter: blur(var(--cs-topbar-blur)) saturate(var(--cs-topbar-saturate));
   padding-top: 0;
   padding-bottom: 0;
 }
@@ -76,9 +76,9 @@
 }
 
 #kesson-topbar .topbar-main-title {
-  color: var(--kesson-topbar-title-color);
-  font-family: var(--kesson-font-serif-display);
-  font-size: var(--kesson-topbar-main-title-size);
+  color: var(--cs-topbar-title-color);
+  font-family: var(--ds-font-serif-display);
+  font-size: var(--cs-topbar-main-title-size);
   letter-spacing: 0.04em;
   line-height: 1;
   text-transform: none;
@@ -90,12 +90,12 @@
 
 #kesson-topbar .topbar-main-title:hover,
 #kesson-topbar .topbar-main-title:focus-visible {
-  color: var(--kesson-topbar-title-hover-color);
+  color: var(--cs-topbar-title-hover-color);
 }
 
 #kesson-topbar .topbar-status-badge {
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-topbar-credit-size);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--cs-topbar-credit-size);
   letter-spacing: 0.08em;
   padding: 0.2rem 0.5rem;
   line-height: 1.1;
@@ -103,9 +103,9 @@
 }
 
 #kesson-topbar .topbar-subtitle {
-  font-size: var(--kesson-topbar-subtitle-size);
-  color: var(--kesson-topbar-subtitle-color);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-size: var(--cs-topbar-subtitle-size);
+  color: var(--cs-topbar-subtitle-color);
+  letter-spacing: var(--ds-letter-ui-wide);
   line-height: 1;
   text-transform: none;
   flex: 0 0 auto;
@@ -115,7 +115,7 @@
 #kesson-topbar .topbar-subtitle::before,
 #kesson-topbar .topbar-meta::before {
   content: '·';
-  color: var(--kesson-topbar-divider-color);
+  color: var(--cs-topbar-divider-color);
   margin-right: 0.45rem;
 }
 
@@ -123,23 +123,23 @@
   display: block;
   flex: 0 0 auto;
   padding: 0;
-  font-size: var(--kesson-topbar-meta-size);
+  font-size: var(--cs-topbar-meta-size);
   line-height: 1;
   letter-spacing: 0.05em;
-  color: var(--kesson-topbar-meta-color);
-  font-family: var(--kesson-font-serif-ui);
+  color: var(--cs-topbar-meta-color);
+  font-family: var(--ds-font-serif-ui);
   pointer-events: none;
 }
 
 #kesson-topbar .topbar-meta--author {
-  font-size: var(--kesson-topbar-meta-author-size);
-  color: var(--kesson-topbar-meta-author-color);
+  font-size: var(--cs-topbar-meta-author-size);
+  color: var(--cs-topbar-meta-author-color);
 }
 
 #kesson-topbar .topbar-link {
-  color: var(--kesson-topbar-link-color);
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-topbar-link-size);
+  color: var(--cs-topbar-link-color);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--cs-topbar-link-size);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   padding: 0.4rem 0.72rem;
@@ -149,8 +149,8 @@
 
 #kesson-topbar .topbar-link:hover,
 #kesson-topbar .topbar-link:focus-visible {
-  color: var(--kesson-topbar-link-hover-color);
-  background: var(--kesson-topbar-link-hover-bg);
+  color: var(--cs-topbar-link-hover-color);
+  background: var(--cs-topbar-link-hover-bg);
 }
 
 #kesson-topbar .topbar-link-btn {
@@ -162,28 +162,28 @@
 }
 
 #kesson-topbar .topbar-lang-btn {
-  color: var(--kesson-topbar-lang-color);
-  border: 1px solid var(--kesson-topbar-lang-border);
-  background: var(--kesson-topbar-lang-bg);
+  color: var(--cs-topbar-lang-color);
+  border: 1px solid var(--cs-topbar-lang-border);
+  background: var(--cs-topbar-lang-bg);
 }
 
 #kesson-topbar .topbar-collab-item {
   margin-left: 0.45rem;
   padding-left: 0.55rem;
-  border-left: 1px solid var(--kesson-topbar-note-divider-color);
+  border-left: 1px solid var(--cs-topbar-note-divider-color);
 }
 
 #kesson-topbar .topbar-collab-note {
   display: inline-block;
-  font-family: var(--kesson-font-serif-ui);
-  font-size: var(--kesson-topbar-note-size);
+  font-family: var(--ds-font-serif-ui);
+  font-size: var(--cs-topbar-note-size);
   line-height: 1;
-  letter-spacing: var(--kesson-letter-ui-normal);
-  color: var(--kesson-topbar-note-color);
+  letter-spacing: var(--ds-letter-ui-normal);
+  color: var(--cs-topbar-note-color);
   white-space: nowrap;
   margin-left: 0.5rem;
   padding-left: 0.56rem;
-  border-left: 1px solid var(--kesson-topbar-note-divider-color);
+  border-left: 1px solid var(--cs-topbar-note-divider-color);
   min-width: 0;
   max-width: min(42vw, 18rem);
   overflow: hidden;
@@ -197,19 +197,19 @@
 }
 
 .topbar-font-btn {
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-topbar-credit-size, 0.80rem);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--cs-topbar-credit-size, 0.80rem);
   letter-spacing: 0.08em;
   padding: 0.2rem 0.5rem;
   background: transparent;
-  border: 1px solid var(--kesson-topbar-nav-border);
-  color: var(--kesson-topbar-link-color);
+  border: 1px solid var(--cs-topbar-nav-border);
+  color: var(--cs-topbar-link-color);
   line-height: 1.4;
 }
 
 .topbar-font-btn:hover:not(:disabled) {
-  background: var(--kesson-topbar-link-hover-bg);
-  color: var(--kesson-topbar-link-hover-color);
+  background: var(--cs-topbar-link-hover-bg);
+  color: var(--cs-topbar-link-hover-color);
 }
 
 .topbar-font-btn:disabled {
@@ -218,20 +218,20 @@
 }
 
 #kesson-topbar .topbar-toggler {
-  border-color: var(--kesson-topbar-toggler-border);
+  border-color: var(--cs-topbar-toggler-border);
   padding: 0.18rem 0.44rem;
 }
 
 #kesson-topbar .topbar-toggler:focus {
-  box-shadow: 0 0 0 0.14rem var(--kesson-topbar-toggler-focus);
+  box-shadow: 0 0 0 0.14rem var(--cs-topbar-toggler-focus);
 }
 
 #kessonTopbarNav {
   margin-top: 0.35rem;
   padding: 0.35rem 0.2rem 0.5rem;
   border-radius: 0.6rem;
-  background: var(--kesson-topbar-nav-bg);
-  border: 1px solid var(--kesson-topbar-nav-border);
+  background: var(--cs-topbar-nav-bg);
+  border: 1px solid var(--cs-topbar-nav-border);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }
@@ -262,7 +262,7 @@
   }
 
   #kesson-topbar .topbar-subtitle {
-    font-size: var(--kesson-topbar-subtitle-size-md);
+    font-size: var(--cs-topbar-subtitle-size-md);
   }
 }
 
@@ -272,11 +272,11 @@
   }
 
   #kesson-topbar .topbar-main-title {
-    font-size: var(--kesson-topbar-main-title-size-sm);
+    font-size: var(--cs-topbar-main-title-size-sm);
   }
 
   #kesson-topbar .topbar-collab-note {
-    font-size: var(--kesson-topbar-credit-size);
+    font-size: var(--cs-topbar-credit-size);
     letter-spacing: 0.05em;
     margin-left: 0.36rem;
     padding-left: 0.36rem;

--- a/src/styles/viewer.css
+++ b/src/styles/viewer.css
@@ -1,39 +1,39 @@
 :root {
-  --kesson-offcanvas-text: #94a3b8;
-  --kesson-offcanvas-heading: #e2e8f0;
-  --kesson-offcanvas-link: #f59e0b;
-  --kesson-offcanvas-width: 85%;
-  --kesson-offcanvas-bg: rgba(10, 14, 26, 0.98);
-  --kesson-viewer-overlay-closed: rgba(5, 10, 20, 0);
-  --kesson-viewer-overlay-open: rgba(5, 10, 20, 0.5);
-  --kesson-viewer-glass-bg: rgba(12, 18, 30, 0.88);
-  --kesson-viewer-glass-border: rgba(var(--color-accent), 0.06);
-  --kesson-viewer-glass-shadow:
+  --cs-offcanvas-text: #94a3b8;
+  --cs-offcanvas-heading: #e2e8f0;
+  --cs-offcanvas-link: #f59e0b;
+  --cs-offcanvas-width: 85%;
+  --cs-offcanvas-bg: rgba(10, 14, 26, 0.98);
+  --cs-viewer-overlay-closed: rgba(5, 10, 20, 0);
+  --cs-viewer-overlay-open: rgba(5, 10, 20, 0.5);
+  --cs-viewer-glass-bg: rgba(12, 18, 30, 0.88);
+  --cs-viewer-glass-border: rgba(var(--color-accent), 0.06);
+  --cs-viewer-glass-shadow:
     0 0 60px rgba(0, 0, 0, 0.4),
     0 0 120px rgba(30, 60, 120, 0.1),
     inset 0 0 60px rgba(20, 40, 80, 0.05);
-  --kesson-viewer-x-handle: rgba(200, 215, 245, 0.7);
-  --kesson-scrollbar-thumb: #1e293b;
-  --kesson-md-provenance: rgba(140, 160, 200, 0.4);
-  --kesson-md-h1: rgba(240, 245, 255, 0.92);
-  --kesson-md-h1-strong: rgba(240, 245, 255, 0.95);
-  --kesson-md-h2: rgba(230, 240, 255, 0.88);
-  --kesson-md-h3: rgba(220, 230, 250, 0.85);
-  --kesson-md-h4: rgba(210, 225, 245, 0.8);
-  --kesson-md-link: rgba(var(--color-link), 0.85);
-  --kesson-md-link-hover: rgba(160, 195, 255, 1);
-  --kesson-md-quote: rgba(200, 215, 240, 0.7);
-  --kesson-md-inline-code: rgba(180, 210, 255, 0.85);
-  --kesson-md-inline-code-bg: rgba(60, 90, 150, 0.12);
-  --kesson-md-table-head-bg: rgba(40, 60, 100, 0.2);
-  --kesson-md-table-head-text: rgba(220, 230, 250, 0.9);
-  --kesson-md-table-cell-text: rgba(200, 215, 240, 0.75);
-  --kesson-md-strong: rgba(240, 245, 255, 0.95);
-  --kesson-md-em: rgba(200, 215, 240, 0.8);
-  --kesson-md-pre-bg: rgba(8, 12, 24, 0.6);
-  --kesson-md-pdf-link: rgba(160, 185, 240, 0.7);
-  --kesson-md-pdf-link-hover: rgba(200, 220, 255, 0.9);
-  --kesson-md-pdf-link-hover-bg: rgba(60, 90, 150, 0.1);
+  --cs-viewer-x-handle: rgba(200, 215, 245, 0.7);
+  --cs-scrollbar-thumb: #1e293b;
+  --cs-md-provenance: rgba(140, 160, 200, 0.4);
+  --cs-md-h1: rgba(240, 245, 255, 0.92);
+  --cs-md-h1-strong: rgba(240, 245, 255, 0.95);
+  --cs-md-h2: rgba(230, 240, 255, 0.88);
+  --cs-md-h3: rgba(220, 230, 250, 0.85);
+  --cs-md-h4: rgba(210, 225, 245, 0.8);
+  --cs-md-link: rgba(var(--color-link), 0.85);
+  --cs-md-link-hover: rgba(160, 195, 255, 1);
+  --cs-md-quote: rgba(200, 215, 240, 0.7);
+  --cs-md-inline-code: rgba(180, 210, 255, 0.85);
+  --cs-md-inline-code-bg: rgba(60, 90, 150, 0.12);
+  --cs-md-table-head-bg: rgba(40, 60, 100, 0.2);
+  --cs-md-table-head-text: rgba(220, 230, 250, 0.9);
+  --cs-md-table-cell-text: rgba(200, 215, 240, 0.75);
+  --cs-md-strong: rgba(240, 245, 255, 0.95);
+  --cs-md-em: rgba(200, 215, 240, 0.8);
+  --cs-md-pre-bg: rgba(8, 12, 24, 0.6);
+  --cs-md-pdf-link: rgba(160, 185, 240, 0.7);
+  --cs-md-pdf-link-hover: rgba(200, 220, 255, 0.9);
+  --cs-md-pdf-link-hover-bg: rgba(60, 90, 150, 0.1);
 }
 
 .offcanvas-body::-webkit-scrollbar {
@@ -45,14 +45,14 @@
 }
 
 .offcanvas-body::-webkit-scrollbar-thumb {
-  background: var(--kesson-scrollbar-thumb);
+  background: var(--cs-scrollbar-thumb);
   border-radius: 3px;
 }
 
 .offcanvas-kesson {
-  --bs-offcanvas-width: var(--kesson-offcanvas-width);
-  width: var(--kesson-offcanvas-width);
-  background: var(--kesson-offcanvas-bg);
+  --bs-offcanvas-width: var(--cs-offcanvas-width);
+  width: var(--cs-offcanvas-width);
+  background: var(--cs-offcanvas-bg);
 }
 
 .offcanvas-title-spaced {
@@ -82,7 +82,7 @@
   display: none;
   align-items: center;
   justify-content: center;
-  background: var(--kesson-viewer-overlay-closed);
+  background: var(--cs-viewer-overlay-closed);
   transition: background 0.5s ease;
   cursor: pointer;
 }
@@ -92,7 +92,7 @@
 }
 
 #kesson-viewer.open {
-  background: var(--kesson-viewer-overlay-open);
+  background: var(--cs-viewer-overlay-open);
 }
 
 .viewer-glass {
@@ -102,12 +102,12 @@
   height: 85vh;
   cursor: default;
   overflow: hidden;
-  background: var(--kesson-viewer-glass-bg);
+  background: var(--cs-viewer-glass-bg);
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
-  border: 1px solid var(--kesson-viewer-glass-border);
+  border: 1px solid var(--cs-viewer-glass-border);
   border-radius: 3px;
-  box-shadow: var(--kesson-viewer-glass-shadow);
+  box-shadow: var(--cs-viewer-glass-shadow);
   opacity: 0;
   transform: scale(0.92) translateY(20px);
   transition: all 0.5s cubic-bezier(0.22, 1, 0.36, 1);
@@ -177,7 +177,7 @@
 }
 
 .x-embed-handle {
-  color: var(--kesson-viewer-x-handle);
+  color: var(--cs-viewer-x-handle);
   font-size: 0.72rem;
   margin-bottom: 0.25rem;
   letter-spacing: 0.04em;
@@ -211,7 +211,7 @@
 
 .md-provenance {
   font-size: 0.80rem;
-  color: var(--kesson-md-provenance);
+  color: var(--cs-md-provenance);
   margin-bottom: 1.5rem;
   letter-spacing: 0.03em;
 }
@@ -222,7 +222,7 @@
 
 .md-body h1 {
   font-size: 1.2rem;
-  color: var(--kesson-md-h1);
+  color: var(--cs-md-h1);
   margin: 2rem 0 0.8rem;
   line-height: 1.4;
   letter-spacing: normal;
@@ -233,27 +233,27 @@
 
 .md-body h1:first-child {
   font-size: 1.3rem;
-  color: var(--kesson-md-h1-strong);
+  color: var(--cs-md-h1-strong);
   margin-top: 0;
   margin-bottom: 1.2rem;
 }
 
 .md-body h2 {
   font-size: 1.05rem;
-  color: var(--kesson-md-h2);
+  color: var(--cs-md-h2);
   margin: 1.8rem 0 0.7rem;
   line-height: 1.4;
 }
 
 .md-body h3 {
   font-size: 0.95rem;
-  color: var(--kesson-md-h3);
+  color: var(--cs-md-h3);
   margin: 1.4rem 0 0.5rem;
 }
 
 .md-body h4 {
   font-size: 0.9rem;
-  color: var(--kesson-md-h4);
+  color: var(--cs-md-h4);
   margin: 1.2rem 0 0.4rem;
 }
 
@@ -267,7 +267,7 @@
   border-left: 2px solid rgba(var(--color-accent), 0.15);
   padding-left: 1em;
   margin: 1em 0;
-  color: var(--kesson-md-quote);
+  color: var(--cs-md-quote);
   font-style: italic;
 }
 
@@ -278,20 +278,20 @@
 }
 
 .md-body a:hover {
-  color: var(--kesson-md-link-hover);
+  color: var(--cs-md-link-hover);
 }
 
 .md-body strong {
-  color: var(--kesson-md-strong);
+  color: var(--cs-md-strong);
   font-weight: 600;
 }
 
 .md-body em {
-  color: var(--kesson-md-em);
+  color: var(--cs-md-em);
 }
 
 .md-body pre {
-  background: var(--kesson-md-pre-bg);
+  background: var(--cs-md-pre-bg);
   border: 1px solid rgba(var(--color-accent), 0.08);
   border-radius: 3px;
   padding: 1em 1.2em;
@@ -302,7 +302,7 @@
 }
 
 .md-body pre code {
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   font-size: 0.82rem;
   color: rgba(var(--color-sub-text), 0.8);
   background: none;
@@ -313,10 +313,10 @@
 }
 
 .md-body code {
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   font-size: 0.85em;
-  color: var(--kesson-md-inline-code);
-  background: var(--kesson-md-inline-code-bg);
+  color: var(--cs-md-inline-code);
+  background: var(--cs-md-inline-code-bg);
   padding: 0.15em 0.4em;
   border-radius: 2px;
 }
@@ -358,13 +358,13 @@
 }
 
 .md-body th {
-  background: var(--kesson-md-table-head-bg);
-  color: var(--kesson-md-table-head-text);
+  background: var(--cs-md-table-head-bg);
+  color: var(--cs-md-table-head-text);
   font-weight: 500;
 }
 
 .md-body td {
-  color: var(--kesson-md-table-cell-text);
+  color: var(--cs-md-table-cell-text);
 }
 
 .md-body img {
@@ -385,7 +385,7 @@
   display: inline-block;
   padding: 0.6em 1.5em;
   font-size: 0.78rem;
-  color: var(--kesson-md-pdf-link);
+  color: var(--cs-md-pdf-link);
   border: 1px solid rgba(var(--color-accent), 0.12);
   border-radius: 2px;
   text-decoration: none;
@@ -394,9 +394,9 @@
 }
 
 .md-pdf-link:hover {
-  color: var(--kesson-md-pdf-link-hover);
+  color: var(--cs-md-pdf-link-hover);
   border-color: rgba(var(--color-accent), 0.25);
-  background: var(--kesson-md-pdf-link-hover-bg);
+  background: var(--cs-md-pdf-link-hover-bg);
 }
 
 .md-loading {

--- a/src/topbar-nav.js
+++ b/src/topbar-nav.js
@@ -1,4 +1,4 @@
-const TOPBAR_ACTUAL_HEIGHT_VAR = '--kesson-topbar-actual-height';
+const TOPBAR_ACTUAL_HEIGHT_VAR = '--cs-topbar-actual-height';
 
 function syncTopbarHeight() {
     const topbar = document.getElementById('kesson-topbar');


### PR DESCRIPTION
## 概要

cs/src/styles で **102 個の `--kesson-*` token が未定義参照** (fallback なし) となっており、本番 deploy で `unset` となる潜在 bug を解消。

詳細: cs#236, techo#128 Phase 1a 棚卸し ([techo/docs/reviews/20260426-kesson-tokens-inventory.md](https://github.com/uminomae/techo/blob/main/docs/reviews/20260426-kesson-tokens-inventory.md))

## 変更内容

| Layer | token 数 | 置換 |
|-------|---------|------|
| A (pd `--ds-*` 既存) | 38 | `--ds-*` 直接参照 |
| B-undef (cs 未定義参照) | 102 | `--cs-*` リネーム + ks origin 値取り込み |
| B-existing (cs 既存値) | 8 | `--cs-*` リネーム |
| C-1 (cs 半移行済) | 1 | `--cs-*` リネーム |
| UNKNOWN-shadow | 1 | `--cs-viewer-glass-shadow` (multi-line 値取り込み) |
| UNKNOWN-dynamic | 1 | `--cs-topbar-actual-height` (JS setProperty 連動) |

**影響**: 12 css + 2 js + 1 html + 1 docs = 17 files (+647 / -568)

## 検証済

- [x] `grep -rn "\-\-kesson-" src/ index.html dev-components.html` で残存ゼロ (コメント 2 行除く)
- [x] tokens.css 内 var 重複なし
- [x] tokens.css braces matched
- [x] sed は token 名長さ降順 → 部分一致衝突なし

## 動作確認 (要 reviewer)

- [ ] dev サーバ起動 → `index.html` の topbar / viewer / md レンダリング
- [ ] `dev-components.html` の各セクション
- [ ] `?dev` パラメータで dev-hud / dev-panel
- [ ] font-size-ctrl の動作 (`--cs-font-size-ui-*` setProperty)

## 並行依存

本 PR は **依存なしで merge 可** (Layer B は暫定 `--cs-*`、後の Phase 2 で pd `--ds-*` / `--pd-*` 昇格時に剥がす)。

- pd#86 (import 方式 ADR): 本 PR には影響なし
- pd#88 (`--pd-*` prefix 統一): Phase 2 着手時に依存

## 関連

- 親: [techo#128](https://github.com/uminomae/techo/issues/128) (Phase 1a 棚卸し)
- 指示書: [cs#236](https://github.com/uminomae/creation-space/issues/236)
- 成果物: [techo/docs/reviews/20260426-cs-mapping.tsv](https://github.com/uminomae/techo/blob/main/docs/reviews/20260426-cs-mapping.tsv) / [cs-tokens-new.css](https://github.com/uminomae/techo/blob/main/docs/reviews/20260426-cs-tokens-new.css) / [cs-replace-cmds.sh](https://github.com/uminomae/techo/blob/main/docs/reviews/20260426-cs-replace-cmds.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)